### PR TITLE
added providerSettings to account object

### DIFF
--- a/src/test/java/com/github/juliusd/ueberboeseapi/UeberboeseExperimentalControllerTest.java
+++ b/src/test/java/com/github/juliusd/ueberboeseapi/UeberboeseExperimentalControllerTest.java
@@ -43,463 +43,462 @@ class UeberboeseExperimentalControllerTest extends TestBase {
   @Test
   void getFullAccount_shouldReturnCompleteAccountDetails() {
     // language=XML
-    String expectedXml =
-        """
-       <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-       <account id="6921042">
-         <accountStatus>CHANGE_PASSWORD</accountStatus>
-         <devices>
-           <device deviceid="123980WER">
-             <attachedProduct product_code="SoundTouch 10 sm2">
-               <components/>
-               <productlabel>soundtouch_10</productlabel>
-               <serialnumber>123SERIA1</serialnumber>
-             </attachedProduct>
-             <createdOn>2018-08-11T08:55:25.000+00:00</createdOn>
-             <firmwareVersion>27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29</firmwareVersion>
-             <ipaddress>192.168.178.2</ipaddress>
-             <name>Foobar</name>
-             <presets>
-               <preset buttonNumber="1">
-                 <containerArt>http://example.org/s80044q.png</containerArt>
-                 <contentItemType>stationurl</contentItemType>
-                 <createdOn>2018-11-26T18:40:45.000+00:00</createdOn>
-                 <location>/v1/playback/station/s80044</location>
-                 <name>Radio Foobar</name>
-                 <source id="19989342" type="Audio">
-                   <createdOn>${xmlunit.isDateTime}</createdOn>
-                   <credential type="token">eyJduTune=</credential>
-                   <name></name>
-                   <sourceproviderid>25</sourceproviderid>
-                   <sourcename></sourcename>
-                   <sourceSettings/>
-                   <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                   <username></username>
-                 </source>
-                 <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                 <username>Radio Foobar</username>
-               </preset>
-               <preset buttonNumber="2">
-                 <containerArt>
-                   https://example.org/300/longtext1
-                 </containerArt>
-                 <contentItemType>tracklisturl</contentItemType>
-                 <createdOn>${xmlunit.isDateTime}</createdOn>
-                 <location>/playback/container/131311232312121212</location>
-                 <name>Radio Foobar</name>
-                 <source id="19989643" type="Audio">
-                   <createdOn>${xmlunit.isDateTime}</createdOn>
-                   <credential type="token_version_3">mockTokenUser2</credential>
-                   <name>user1namespot</name>
-                   <sourceproviderid>15</sourceproviderid>
-                   <sourcename>user1@example.org</sourcename>
-                   <sourceSettings/>
-                   <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                   <username>user1namespot</username>
-                 </source>
-                 <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                 <username>Radio Bar</username>
-               </preset>
-               <preset buttonNumber="3">
-                 <containerArt>https://example.org/s25111/images/logoq.jpg?t=1</containerArt>
-                 <contentItemType>stationurl</contentItemType>
-                 <createdOn>${xmlunit.isDateTime}</createdOn>
-                 <location>/v1/playback/station/s25111</location>
-                 <name>radioonetwo</name>
-                 <source id="19989342" type="Audio">
-                   <createdOn>${xmlunit.isDateTime}</createdOn>
-                   <credential type="token">eyJduTune=</credential>
-                   <name></name>
-                   <sourceproviderid>25</sourceproviderid>
-                   <sourcename></sourcename>
-                   <sourceSettings/>
-                   <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                   <username></username>
-                 </source>
-                 <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                 <username>radioeins vom rbb</username>
-               </preset>
-               <preset buttonNumber="4">
-                 <containerArt>
-                   https://example.org/300/longtext2
-                 </containerArt>
-                 <contentItemType>tracklisturl</contentItemType>
-                 <createdOn>${xmlunit.isDateTime}</createdOn>
-                 <location>/playback/container/45345349538</location>
-                 <name>Kids</name>
-                 <source id="19989643" type="Audio">
-                   <createdOn>${xmlunit.isDateTime}</createdOn>
-                   <credential type="token_version_3">mockTokenUser2</credential>
-                   <name>user1namespot</name>
-                   <sourceproviderid>15</sourceproviderid>
-                   <sourcename>user1@example.org</sourcename>
-                   <sourceSettings/>
-                   <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                   <username>user1namespot</username>
-                 </source>
-                 <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                 <username>Kids</username>
-               </preset>
-               <preset buttonNumber="5">
-                 <containerArt></containerArt>
-                 <contentItemType>tracklisturl</contentItemType>
-                 <createdOn>${xmlunit.isDateTime}</createdOn>
-                 <location>/playback/container/urlssfdfsd</location>
-                 <name>Artist Radio</name>
-                 <source id="20260226" type="Audio">
-                   <createdOn>${xmlunit.isDateTime}</createdOn>
-                   <credential type="token_version_3">
-                     ${xmlunit.ignore}
-                   </credential>
-                   <name>${xmlunit.ignore}</name>
-                   <sourceproviderid>15</sourceproviderid>
-                   <sourcename>${xmlunit.ignore}</sourcename>
-                   <sourceSettings/>
-                   <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                   <username>${xmlunit.ignore}</username>
-                 </source>
-                 <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                 <username>Artist Radio</username>
-               </preset>
-               <preset buttonNumber="6">
-                 <containerArt>https://example.org/image/ab67706c0000da843b38733ef58fbd3530776a42
-                 </containerArt>
-                 <contentItemType>tracklisturl</contentItemType>
-                 <createdOn>${xmlunit.isDateTime}</createdOn>
-                 <location>/playback/container/577667532256ht</location>
-                 <name>Komplett Entspannt</name>
-                 <source id="19989643" type="Audio">
-                   <createdOn>${xmlunit.isDateTime}</createdOn>
-                   <credential type="token_version_3">mockTokenUser2</credential>
-                   <name>user1namespot</name>
-                   <sourceproviderid>15</sourceproviderid>
-                   <sourcename>user1@example.org</sourcename>
-                   <sourceSettings/>
-                   <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                   <username>user1namespot</username>
-                 </source>
-                 <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                 <username>Komplett Entspannt</username>
-               </preset>
-             </presets>
-             <recents>
-               <recent id="${xmlunit.isNumber}">
-                 <contentItemType>tracklisturl</contentItemType>
-                 <createdOn>${xmlunit.isDateTime}</createdOn>
-                 <lastplayedat>${xmlunit.isDateTime}</lastplayedat>
-                 <location>/playback/container/c3BvdGlmeTphbGJ1bTowZ3BGWVZNbVV6VkVxeVAyeUh3cEha</location>
-                 <name>Ghostsitter 42 - Das Haus im Moor</name>
-                 <source id="19989643" type="Audio">
-                   <createdOn>${xmlunit.isDateTime}</createdOn>
-                   <credential type="token_version_3">mockTokenUser2</credential>
-                   <name>user1namespot</name>
-                   <sourceproviderid>15</sourceproviderid>
-                   <sourcename>user1@example.org</sourcename>
-                   <sourceSettings/>
-                   <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                   <username>user1namespot</username>
-                 </source>
-                 <sourceid>19989643</sourceid>
-                 <updatedOn>${xmlunit.isDateTime}</updatedOn>
-               </recent>
-               <recent id="${xmlunit.isNumber}">
-                 <contentItemType>stationurl</contentItemType>
-                 <createdOn>${xmlunit.isDateTime}</createdOn>
-                 <lastplayedat>${xmlunit.isDateTime}</lastplayedat>
-                 <location>/v1/playback/station/s80044</location>
-                 <name>Radio TEDDY</name>
-                 <source id="19989342" type="Audio">
-                   <createdOn>2018-08-11T08:55:28.000+00:00</createdOn>
-                   <credential type="token">eyJduTune=</credential>
-                   <name/>
-                   <sourceproviderid>25</sourceproviderid>
-                   <sourcename/>
-                   <sourceSettings/>
-                   <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                   <username/>
-                 </source>
-                 <sourceid>19989342</sourceid>
-                 <updatedOn>${xmlunit.isDateTime}</updatedOn>
-               </recent>
-             </recents>
-             <serialNumber>PUP43434234</serialNumber>
-             <updatedOn>2025-09-06T08:25:49.000+00:00</updatedOn>
-           </device>
-           <device deviceid="42342FF23">
-             <attachedProduct product_code="SoundTouch 20 sm2">
-               <components/>
-               <productlabel>soundtouch_20_series3</productlabel>
-               <serialnumber>7878SERI001</serialnumber>
-             </attachedProduct>
-             <createdOn>2020-01-25T09:21:42.000+00:00</createdOn>
-             <firmwareVersion>27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29</firmwareVersion>
-             <ipaddress>192.168.178.3</ipaddress>
-             <name>SoundTouch 20</name>
-             <presets>
-               <preset buttonNumber="1">
-                 <containerArt>http://example.org/s80044q.png</containerArt>
-                 <contentItemType>stationurl</contentItemType>
-                 <createdOn>2018-11-26T18:40:45.000+00:00</createdOn>
-                 <location>/v1/playback/station/s80044</location>
-                 <name>Radio Foobar</name>
-                 <source id="19989342" type="Audio">
-                   <createdOn>${xmlunit.isDateTime}</createdOn>
-                   <credential type="token">eyJduTune=</credential>
-                   <name></name>
-                   <sourceproviderid>25</sourceproviderid>
-                   <sourcename></sourcename>
-                   <sourceSettings/>
-                   <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                   <username></username>
-                 </source>
-                 <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                 <username>Radio Foobar</username>
-               </preset>
-               <preset buttonNumber="2">
-                 <containerArt>
-                   https://example.org/300/longtext1
-                 </containerArt>
-                 <contentItemType>tracklisturl</contentItemType>
-                 <createdOn>${xmlunit.isDateTime}</createdOn>
-                 <location>/playback/container/131311232312121212</location>
-                 <name>Radio Foobar</name>
-                 <source id="19989643" type="Audio">
-                   <createdOn>${xmlunit.isDateTime}</createdOn>
-                   <credential type="token_version_3">mockTokenUser2</credential>
-                   <name>user1namespot</name>
-                   <sourceproviderid>15</sourceproviderid>
-                   <sourcename>user1@example.org</sourcename>
-                   <sourceSettings/>
-                   <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                   <username>user1namespot</username>
-                 </source>
-                 <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                 <username>Radio Bar</username>
-               </preset>
-               <preset buttonNumber="3">
-                 <containerArt>https://example.org/s25111/images/logoq.jpg?t=1</containerArt>
-                 <contentItemType>stationurl</contentItemType>
-                 <createdOn>${xmlunit.isDateTime}</createdOn>
-                 <location>/v1/playback/station/s25111</location>
-                 <name>radioonetwo</name>
-                 <source id="19989342" type="Audio">
-                   <createdOn>${xmlunit.isDateTime}</createdOn>
-                   <credential type="token">eyJduTune=</credential>
-                   <name></name>
-                   <sourceproviderid>25</sourceproviderid>
-                   <sourcename></sourcename>
-                   <sourceSettings/>
-                   <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                   <username></username>
-                 </source>
-                 <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                 <username>radioeins vom rbb</username>
-               </preset>
-               <preset buttonNumber="4">
-                 <containerArt>
-                   https://example.org/300/longtext2
-                 </containerArt>
-                 <contentItemType>tracklisturl</contentItemType>
-                 <createdOn>${xmlunit.isDateTime}</createdOn>
-                 <location>/playback/container/45345349538</location>
-                 <name>Kids</name>
-                 <source id="19989643" type="Audio">
-                   <createdOn>${xmlunit.isDateTime}</createdOn>
-                   <credential type="token_version_3">mockTokenUser2</credential>
-                   <name>user1namespot</name>
-                   <sourceproviderid>15</sourceproviderid>
-                   <sourcename>user1@example.org</sourcename>
-                   <sourceSettings/>
-                   <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                   <username>user1namespot</username>
-                 </source>
-                 <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                 <username>Kids</username>
-               </preset>
-               <preset buttonNumber="5">
-                 <containerArt></containerArt>
-                 <contentItemType>tracklisturl</contentItemType>
-                 <createdOn>${xmlunit.isDateTime}</createdOn>
-                 <location>/playback/container/urlssfdfsd</location>
-                 <name>Artist Radio</name>
-                 <source id="20260226" type="Audio">
-                   <createdOn>${xmlunit.isDateTime}</createdOn>
-                   <credential type="token_version_3">
-                     ${xmlunit.ignore}
-                   </credential>
-                   <name>${xmlunit.ignore}</name>
-                   <sourceproviderid>15</sourceproviderid>
-                   <sourcename>${xmlunit.ignore}</sourcename>
-                   <sourceSettings/>
-                   <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                   <username>${xmlunit.ignore}</username>
-                 </source>
-                 <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                 <username>Artist Radio</username>
-               </preset>
-               <preset buttonNumber="6">
-                 <containerArt>https://example.org/image/ab67706c0000da843b38733ef58fbd3530776a42
-                 </containerArt>
-                 <contentItemType>tracklisturl</contentItemType>
-                 <createdOn>${xmlunit.isDateTime}</createdOn>
-                 <location>/playback/container/577667532256ht</location>
-                 <name>Komplett Entspannt</name>
-                 <source id="19989643" type="Audio">
-                   <createdOn>${xmlunit.isDateTime}</createdOn>
-                   <credential type="token_version_3">mockTokenUser2</credential>
-                   <name>user1namespot</name>
-                   <sourceproviderid>15</sourceproviderid>
-                   <sourcename>user1@example.org</sourcename>
-                   <sourceSettings/>
-                   <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                   <username>user1namespot</username>
-                 </source>
-                 <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                 <username>Komplett Entspannt</username>
-               </preset>
-             </presets>
-             <recents>
-               <recent id="${xmlunit.isNumber}">
-                 <contentItemType>tracklisturl</contentItemType>
-                 <createdOn>${xmlunit.isDateTime}</createdOn>
-                 <lastplayedat>${xmlunit.isDateTime}</lastplayedat>
-                 <location>/playback/container/c3BvdGlmeTphbGJ1bTowZ3BGWVZNbVV6VkVxeVAyeUh3cEha</location>
-                 <name>Ghostsitter 42 - Das Haus im Moor</name>
-                 <source id="19989643" type="Audio">
-                   <createdOn>${xmlunit.isDateTime}</createdOn>
-                   <credential type="token_version_3">mockTokenUser2</credential>
-                   <name>user1namespot</name>
-                   <sourceproviderid>15</sourceproviderid>
-                   <sourcename>user1@example.org</sourcename>
-                   <sourceSettings/>
-                   <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                   <username>user1namespot</username>
-                 </source>
-                 <sourceid>19989643</sourceid>
-                 <updatedOn>${xmlunit.isDateTime}</updatedOn>
-               </recent>
-               <recent id="${xmlunit.isNumber}">
-                 <contentItemType>stationurl</contentItemType>
-                 <createdOn>${xmlunit.isDateTime}</createdOn>
-                 <lastplayedat>${xmlunit.isDateTime}</lastplayedat>
-                 <location>/v1/playback/station/s80044</location>
-                 <name>Radio TEDDY</name>
-                 <source id="19989342" type="Audio">
-                   <createdOn>2018-08-11T08:55:28.000+00:00</createdOn>
-                   <credential type="token">eyJduTune=</credential>
-                   <name/>
-                   <sourceproviderid>25</sourceproviderid>
-                   <sourcename/>
-                   <sourceSettings/>
-                   <updatedOn>${xmlunit.isDateTime}</updatedOn>
-                   <username/>
-                 </source>
-                 <sourceid>19989342</sourceid>
-                 <updatedOn>${xmlunit.isDateTime}</updatedOn>
-               </recent>
-             </recents>
-             <serialNumber>SERI234980432894284848</serialNumber>
-             <updatedOn>2020-09-24T05:42:07.000+00:00</updatedOn>
-           </device>
-         </devices>
-         <mode>global</mode>
-         <preferredLanguage>de</preferredLanguage>
-         <sources>
-           <source id="19989552" type="Audio">
-             <createdOn>2018-08-11T08:55:28.000+00:00</createdOn>
-             <credential type="token"></credential>
-             <name></name>
-             <sourceproviderid>2</sourceproviderid>
-             <sourcename></sourcename>
-             <sourceSettings/>
-             <updatedOn>2018-08-11T08:55:28.000+00:00</updatedOn>
-             <username></username>
-           </source>
-           <source id="25443887" type="Audio">
-             <createdOn>${xmlunit.isDateTime}</createdOn>
-             <credential type="token"></credential>
-             <name>647d54be-81e8-4351-95b1-30775853c8af/0</name>
-             <sourceproviderid>7</sourceproviderid>
-             <sourcename>Mediaserver</sourcename>
-             <sourceSettings/>
-             <updatedOn>${xmlunit.isDateTime}</updatedOn>
-             <username>647d54be-81e8-4351-95b1-30775853c8af/0</username>
-           </source>
-           <source id="21465524" type="Audio">
-             <createdOn>${xmlunit.isDateTime}</createdOn>
-             <credential type="token">eyJWasgeHt2=</credential>
-             <name></name>
-             <sourceproviderid>11</sourceproviderid>
-             <sourcename></sourcename>
-             <sourceSettings/>
-             <updatedOn>${xmlunit.isDateTime}</updatedOn>
-             <username></username>
-           </source>
-           <source id="20260226" type="Audio">
-             <createdOn>${xmlunit.isDateTime}</createdOn>
-             <credential type="token_version_3">
-               token-User2-Spot
-             </credential>
-             <name>user2namespot</name>
-             <sourceproviderid>15</sourceproviderid>
-             <sourcename>user2@example.org</sourcename>
-             <sourceSettings/>
-             <updatedOn>${xmlunit.isDateTime}</updatedOn>
-             <username>user2namespot</username>
-           </source>
-           <source id="19989643" type="Audio">
-             <createdOn>${xmlunit.isDateTime}</createdOn>
-             <credential type="token_version_3">
-               mockTokenUser2
-             </credential>
-             <name>user1namespot</name>
-             <sourceproviderid>15</sourceproviderid>
-             <sourcename>user1@example.org</sourcename>
-             <sourceSettings/>
-             <updatedOn>${xmlunit.isDateTime}</updatedOn>
-             <username>user1namespot</username>
-           </source>
-           <source id="19989342" type="Audio">
-             <createdOn>${xmlunit.isDateTime}</createdOn>
-             <credential type="token">eyJduTune=</credential>
-             <name></name>
-             <sourceproviderid>25</sourceproviderid>
-             <sourcename></sourcename>
-             <sourceSettings/>
-             <updatedOn>${xmlunit.isDateTime}</updatedOn>
-             <username></username>
-           </source>
-           <source id="26668320" type="Audio">
-             <createdOn>${xmlunit.isDateTime}</createdOn>
-             <credential type="token">cf8ba540-711c-4f1c-bebc-f0edcca14676</credential>
-             <name></name>
-             <sourceproviderid>35</sourceproviderid>
-             <sourcename></sourcename>
-             <sourceSettings/>
-             <updatedOn>${xmlunit.isDateTime}</updatedOn>
-             <username></username>
-           </source>
-         </sources>
-       </account>
-       """;
+    String expectedXml = """
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <account id="6921042">
+          <accountStatus>CHANGE_PASSWORD</accountStatus>
+          <devices>
+            <device deviceid="123980WER">
+              <attachedProduct product_code="SoundTouch 10 sm2">
+                <components/>
+                <productlabel>soundtouch_10</productlabel>
+                <serialnumber>123SERIA1</serialnumber>
+              </attachedProduct>
+              <createdOn>2018-08-11T08:55:25.000+00:00</createdOn>
+              <firmwareVersion>27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29</firmwareVersion>
+              <ipaddress>192.168.178.2</ipaddress>
+              <name>Foobar</name>
+              <presets>
+                <preset buttonNumber="1">
+                  <containerArt>http://example.org/s80044q.png</containerArt>
+                  <contentItemType>stationurl</contentItemType>
+                  <createdOn>2018-11-26T18:40:45.000+00:00</createdOn>
+                  <location>/v1/playback/station/s80044</location>
+                  <name>Radio Foobar</name>
+                  <source id="19989342" type="Audio">
+                    <createdOn>${xmlunit.isDateTime}</createdOn>
+                    <credential type="token">eyJduTune=</credential>
+                    <name></name>
+                    <sourceproviderid>25</sourceproviderid>
+                    <sourcename></sourcename>
+                    <sourceSettings/>
+                    <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                    <username></username>
+                  </source>
+                  <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                  <username>Radio Foobar</username>
+                </preset>
+                <preset buttonNumber="2">
+                  <containerArt>
+                    https://example.org/300/longtext1
+                  </containerArt>
+                  <contentItemType>tracklisturl</contentItemType>
+                  <createdOn>${xmlunit.isDateTime}</createdOn>
+                  <location>/playback/container/131311232312121212</location>
+                  <name>Radio Foobar</name>
+                  <source id="19989643" type="Audio">
+                    <createdOn>${xmlunit.isDateTime}</createdOn>
+                    <credential type="token_version_3">mockTokenUser2</credential>
+                    <name>user1namespot</name>
+                    <sourceproviderid>15</sourceproviderid>
+                    <sourcename>user1@example.org</sourcename>
+                    <sourceSettings/>
+                    <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                    <username>user1namespot</username>
+                  </source>
+                  <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                  <username>Radio Bar</username>
+                </preset>
+                <preset buttonNumber="3">
+                  <containerArt>https://example.org/s25111/images/logoq.jpg?t=1</containerArt>
+                  <contentItemType>stationurl</contentItemType>
+                  <createdOn>${xmlunit.isDateTime}</createdOn>
+                  <location>/v1/playback/station/s25111</location>
+                  <name>radioonetwo</name>
+                  <source id="19989342" type="Audio">
+                    <createdOn>${xmlunit.isDateTime}</createdOn>
+                    <credential type="token">eyJduTune=</credential>
+                    <name></name>
+                    <sourceproviderid>25</sourceproviderid>
+                    <sourcename></sourcename>
+                    <sourceSettings/>
+                    <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                    <username></username>
+                  </source>
+                  <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                  <username>radioeins vom rbb</username>
+                </preset>
+                <preset buttonNumber="4">
+                  <containerArt>
+                    https://example.org/300/longtext2
+                  </containerArt>
+                  <contentItemType>tracklisturl</contentItemType>
+                  <createdOn>${xmlunit.isDateTime}</createdOn>
+                  <location>/playback/container/45345349538</location>
+                  <name>Kids</name>
+                  <source id="19989643" type="Audio">
+                    <createdOn>${xmlunit.isDateTime}</createdOn>
+                    <credential type="token_version_3">mockTokenUser2</credential>
+                    <name>user1namespot</name>
+                    <sourceproviderid>15</sourceproviderid>
+                    <sourcename>user1@example.org</sourcename>
+                    <sourceSettings/>
+                    <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                    <username>user1namespot</username>
+                  </source>
+                  <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                  <username>Kids</username>
+                </preset>
+                <preset buttonNumber="5">
+                  <containerArt></containerArt>
+                  <contentItemType>tracklisturl</contentItemType>
+                  <createdOn>${xmlunit.isDateTime}</createdOn>
+                  <location>/playback/container/urlssfdfsd</location>
+                  <name>Artist Radio</name>
+                  <source id="20260226" type="Audio">
+                    <createdOn>${xmlunit.isDateTime}</createdOn>
+                    <credential type="token_version_3">
+                      ${xmlunit.ignore}
+                    </credential>
+                    <name>${xmlunit.ignore}</name>
+                    <sourceproviderid>15</sourceproviderid>
+                    <sourcename>${xmlunit.ignore}</sourcename>
+                    <sourceSettings/>
+                    <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                    <username>${xmlunit.ignore}</username>
+                  </source>
+                  <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                  <username>Artist Radio</username>
+                </preset>
+                <preset buttonNumber="6">
+                  <containerArt>https://example.org/image/ab67706c0000da843b38733ef58fbd3530776a42
+                  </containerArt>
+                  <contentItemType>tracklisturl</contentItemType>
+                  <createdOn>${xmlunit.isDateTime}</createdOn>
+                  <location>/playback/container/577667532256ht</location>
+                  <name>Komplett Entspannt</name>
+                  <source id="19989643" type="Audio">
+                    <createdOn>${xmlunit.isDateTime}</createdOn>
+                    <credential type="token_version_3">mockTokenUser2</credential>
+                    <name>user1namespot</name>
+                    <sourceproviderid>15</sourceproviderid>
+                    <sourcename>user1@example.org</sourcename>
+                    <sourceSettings/>
+                    <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                    <username>user1namespot</username>
+                  </source>
+                  <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                  <username>Komplett Entspannt</username>
+                </preset>
+              </presets>
+              <recents>
+                <recent id="${xmlunit.isNumber}">
+                  <contentItemType>tracklisturl</contentItemType>
+                  <createdOn>${xmlunit.isDateTime}</createdOn>
+                  <lastplayedat>${xmlunit.isDateTime}</lastplayedat>
+                  <location>/playback/container/c3BvdGlmeTphbGJ1bTowZ3BGWVZNbVV6VkVxeVAyeUh3cEha</location>
+                  <name>Ghostsitter 42 - Das Haus im Moor</name>
+                  <source id="19989643" type="Audio">
+                    <createdOn>${xmlunit.isDateTime}</createdOn>
+                    <credential type="token_version_3">mockTokenUser2</credential>
+                    <name>user1namespot</name>
+                    <sourceproviderid>15</sourceproviderid>
+                    <sourcename>user1@example.org</sourcename>
+                    <sourceSettings/>
+                    <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                    <username>user1namespot</username>
+                  </source>
+                  <sourceid>19989643</sourceid>
+                  <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                </recent>
+                <recent id="${xmlunit.isNumber}">
+                  <contentItemType>stationurl</contentItemType>
+                  <createdOn>${xmlunit.isDateTime}</createdOn>
+                  <lastplayedat>${xmlunit.isDateTime}</lastplayedat>
+                  <location>/v1/playback/station/s80044</location>
+                  <name>Radio TEDDY</name>
+                  <source id="19989342" type="Audio">
+                    <createdOn>2018-08-11T08:55:28.000+00:00</createdOn>
+                    <credential type="token">eyJduTune=</credential>
+                    <name/>
+                    <sourceproviderid>25</sourceproviderid>
+                    <sourcename/>
+                    <sourceSettings/>
+                    <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                    <username/>
+                  </source>
+                  <sourceid>19989342</sourceid>
+                  <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                </recent>
+              </recents>
+              <serialNumber>PUP43434234</serialNumber>
+              <updatedOn>2025-09-06T08:25:49.000+00:00</updatedOn>
+            </device>
+            <device deviceid="42342FF23">
+              <attachedProduct product_code="SoundTouch 20 sm2">
+                <components/>
+                <productlabel>soundtouch_20_series3</productlabel>
+                <serialnumber>7878SERI001</serialnumber>
+              </attachedProduct>
+              <createdOn>2020-01-25T09:21:42.000+00:00</createdOn>
+              <firmwareVersion>27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29</firmwareVersion>
+              <ipaddress>192.168.178.3</ipaddress>
+              <name>SoundTouch 20</name>
+              <presets>
+                <preset buttonNumber="1">
+                  <containerArt>http://example.org/s80044q.png</containerArt>
+                  <contentItemType>stationurl</contentItemType>
+                  <createdOn>2018-11-26T18:40:45.000+00:00</createdOn>
+                  <location>/v1/playback/station/s80044</location>
+                  <name>Radio Foobar</name>
+                  <source id="19989342" type="Audio">
+                    <createdOn>${xmlunit.isDateTime}</createdOn>
+                    <credential type="token">eyJduTune=</credential>
+                    <name></name>
+                    <sourceproviderid>25</sourceproviderid>
+                    <sourcename></sourcename>
+                    <sourceSettings/>
+                    <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                    <username></username>
+                  </source>
+                  <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                  <username>Radio Foobar</username>
+                </preset>
+                <preset buttonNumber="2">
+                  <containerArt>
+                    https://example.org/300/longtext1
+                  </containerArt>
+                  <contentItemType>tracklisturl</contentItemType>
+                  <createdOn>${xmlunit.isDateTime}</createdOn>
+                  <location>/playback/container/131311232312121212</location>
+                  <name>Radio Foobar</name>
+                  <source id="19989643" type="Audio">
+                    <createdOn>${xmlunit.isDateTime}</createdOn>
+                    <credential type="token_version_3">mockTokenUser2</credential>
+                    <name>user1namespot</name>
+                    <sourceproviderid>15</sourceproviderid>
+                    <sourcename>user1@example.org</sourcename>
+                    <sourceSettings/>
+                    <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                    <username>user1namespot</username>
+                  </source>
+                  <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                  <username>Radio Bar</username>
+                </preset>
+                <preset buttonNumber="3">
+                  <containerArt>https://example.org/s25111/images/logoq.jpg?t=1</containerArt>
+                  <contentItemType>stationurl</contentItemType>
+                  <createdOn>${xmlunit.isDateTime}</createdOn>
+                  <location>/v1/playback/station/s25111</location>
+                  <name>radioonetwo</name>
+                  <source id="19989342" type="Audio">
+                    <createdOn>${xmlunit.isDateTime}</createdOn>
+                    <credential type="token">eyJduTune=</credential>
+                    <name></name>
+                    <sourceproviderid>25</sourceproviderid>
+                    <sourcename></sourcename>
+                    <sourceSettings/>
+                    <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                    <username></username>
+                  </source>
+                  <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                  <username>radioeins vom rbb</username>
+                </preset>
+                <preset buttonNumber="4">
+                  <containerArt>
+                    https://example.org/300/longtext2
+                  </containerArt>
+                  <contentItemType>tracklisturl</contentItemType>
+                  <createdOn>${xmlunit.isDateTime}</createdOn>
+                  <location>/playback/container/45345349538</location>
+                  <name>Kids</name>
+                  <source id="19989643" type="Audio">
+                    <createdOn>${xmlunit.isDateTime}</createdOn>
+                    <credential type="token_version_3">mockTokenUser2</credential>
+                    <name>user1namespot</name>
+                    <sourceproviderid>15</sourceproviderid>
+                    <sourcename>user1@example.org</sourcename>
+                    <sourceSettings/>
+                    <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                    <username>user1namespot</username>
+                  </source>
+                  <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                  <username>Kids</username>
+                </preset>
+                <preset buttonNumber="5">
+                  <containerArt></containerArt>
+                  <contentItemType>tracklisturl</contentItemType>
+                  <createdOn>${xmlunit.isDateTime}</createdOn>
+                  <location>/playback/container/urlssfdfsd</location>
+                  <name>Artist Radio</name>
+                  <source id="20260226" type="Audio">
+                    <createdOn>${xmlunit.isDateTime}</createdOn>
+                    <credential type="token_version_3">
+                      ${xmlunit.ignore}
+                    </credential>
+                    <name>${xmlunit.ignore}</name>
+                    <sourceproviderid>15</sourceproviderid>
+                    <sourcename>${xmlunit.ignore}</sourcename>
+                    <sourceSettings/>
+                    <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                    <username>${xmlunit.ignore}</username>
+                  </source>
+                  <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                  <username>Artist Radio</username>
+                </preset>
+                <preset buttonNumber="6">
+                  <containerArt>https://example.org/image/ab67706c0000da843b38733ef58fbd3530776a42
+                  </containerArt>
+                  <contentItemType>tracklisturl</contentItemType>
+                  <createdOn>${xmlunit.isDateTime}</createdOn>
+                  <location>/playback/container/577667532256ht</location>
+                  <name>Komplett Entspannt</name>
+                  <source id="19989643" type="Audio">
+                    <createdOn>${xmlunit.isDateTime}</createdOn>
+                    <credential type="token_version_3">mockTokenUser2</credential>
+                    <name>user1namespot</name>
+                    <sourceproviderid>15</sourceproviderid>
+                    <sourcename>user1@example.org</sourcename>
+                    <sourceSettings/>
+                    <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                    <username>user1namespot</username>
+                  </source>
+                  <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                  <username>Komplett Entspannt</username>
+                </preset>
+              </presets>
+              <recents>
+                <recent id="${xmlunit.isNumber}">
+                  <contentItemType>tracklisturl</contentItemType>
+                  <createdOn>${xmlunit.isDateTime}</createdOn>
+                  <lastplayedat>${xmlunit.isDateTime}</lastplayedat>
+                  <location>/playback/container/c3BvdGlmeTphbGJ1bTowZ3BGWVZNbVV6VkVxeVAyeUh3cEha</location>
+                  <name>Ghostsitter 42 - Das Haus im Moor</name>
+                  <source id="19989643" type="Audio">
+                    <createdOn>${xmlunit.isDateTime}</createdOn>
+                    <credential type="token_version_3">mockTokenUser2</credential>
+                    <name>user1namespot</name>
+                    <sourceproviderid>15</sourceproviderid>
+                    <sourcename>user1@example.org</sourcename>
+                    <sourceSettings/>
+                    <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                    <username>user1namespot</username>
+                  </source>
+                  <sourceid>19989643</sourceid>
+                  <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                </recent>
+                <recent id="${xmlunit.isNumber}">
+                  <contentItemType>stationurl</contentItemType>
+                  <createdOn>${xmlunit.isDateTime}</createdOn>
+                  <lastplayedat>${xmlunit.isDateTime}</lastplayedat>
+                  <location>/v1/playback/station/s80044</location>
+                  <name>Radio TEDDY</name>
+                  <source id="19989342" type="Audio">
+                    <createdOn>2018-08-11T08:55:28.000+00:00</createdOn>
+                    <credential type="token">eyJduTune=</credential>
+                    <name/>
+                    <sourceproviderid>25</sourceproviderid>
+                    <sourcename/>
+                    <sourceSettings/>
+                    <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                    <username/>
+                  </source>
+                  <sourceid>19989342</sourceid>
+                  <updatedOn>${xmlunit.isDateTime}</updatedOn>
+                </recent>
+              </recents>
+              <serialNumber>SERI234980432894284848</serialNumber>
+              <updatedOn>2020-09-24T05:42:07.000+00:00</updatedOn>
+            </device>
+          </devices>
+          <mode>global</mode>
+          <preferredLanguage>de</preferredLanguage>
+          <sources>
+            <source id="19989552" type="Audio">
+              <createdOn>2018-08-11T08:55:28.000+00:00</createdOn>
+              <credential type="token"></credential>
+              <name></name>
+              <sourceproviderid>2</sourceproviderid>
+              <sourcename></sourcename>
+              <sourceSettings/>
+              <updatedOn>2018-08-11T08:55:28.000+00:00</updatedOn>
+              <username></username>
+            </source>
+            <source id="25443887" type="Audio">
+              <createdOn>${xmlunit.isDateTime}</createdOn>
+              <credential type="token"></credential>
+              <name>647d54be-81e8-4351-95b1-30775853c8af/0</name>
+              <sourceproviderid>7</sourceproviderid>
+              <sourcename>Mediaserver</sourcename>
+              <sourceSettings/>
+              <updatedOn>${xmlunit.isDateTime}</updatedOn>
+              <username>647d54be-81e8-4351-95b1-30775853c8af/0</username>
+            </source>
+            <source id="21465524" type="Audio">
+              <createdOn>${xmlunit.isDateTime}</createdOn>
+              <credential type="token">eyJWasgeHt2=</credential>
+              <name></name>
+              <sourceproviderid>11</sourceproviderid>
+              <sourcename></sourcename>
+              <sourceSettings/>
+              <updatedOn>${xmlunit.isDateTime}</updatedOn>
+              <username></username>
+            </source>
+            <source id="20260226" type="Audio">
+              <createdOn>${xmlunit.isDateTime}</createdOn>
+              <credential type="token_version_3">
+                token-User2-Spot
+              </credential>
+              <name>user2namespot</name>
+              <sourceproviderid>15</sourceproviderid>
+              <sourcename>user2@example.org</sourcename>
+              <sourceSettings/>
+              <updatedOn>${xmlunit.isDateTime}</updatedOn>
+              <username>user2namespot</username>
+            </source>
+            <source id="19989643" type="Audio">
+              <createdOn>${xmlunit.isDateTime}</createdOn>
+              <credential type="token_version_3">
+                mockTokenUser2
+              </credential>
+              <name>user1namespot</name>
+              <sourceproviderid>15</sourceproviderid>
+              <sourcename>user1@example.org</sourcename>
+              <sourceSettings/>
+              <updatedOn>${xmlunit.isDateTime}</updatedOn>
+              <username>user1namespot</username>
+            </source>
+            <source id="19989342" type="Audio">
+              <createdOn>${xmlunit.isDateTime}</createdOn>
+              <credential type="token">eyJduTune=</credential>
+              <name></name>
+              <sourceproviderid>25</sourceproviderid>
+              <sourcename></sourcename>
+              <sourceSettings/>
+              <updatedOn>${xmlunit.isDateTime}</updatedOn>
+              <username></username>
+            </source>
+            <source id="26668320" type="Audio">
+              <createdOn>${xmlunit.isDateTime}</createdOn>
+              <credential type="token">cf8ba540-711c-4f1c-bebc-f0edcca14676</credential>
+              <name></name>
+              <sourceproviderid>35</sourceproviderid>
+              <sourcename></sourcename>
+              <sourceSettings/>
+              <updatedOn>${xmlunit.isDateTime}</updatedOn>
+              <username></username>
+            </source>
+           </sources>
+        <providerSettings/>
+        </account>
+        """;
 
     givenRecentsInDB();
     givenSpotifyAccountsInDB();
 
-    var responseXml =
-        given()
-            .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
-            .header("User-agent", "Bose_Lisa/27.0.6")
-            .header("Authorization", "Bearer foo/qtwq6FH/bar")
-            .when()
-            .get("/streaming/account/6921042/full")
-            .then()
-            .statusCode(200)
-            .contentType("application/vnd.bose.streaming-v1.2+xml")
-            .header("METHOD_NAME", "getFullAccount")
-            .extract()
-            .body()
-            .asString();
+    var responseXml = given()
+        .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
+        .header("User-agent", "Bose_Lisa/27.0.6")
+        .header("Authorization", "Bearer foo/qtwq6FH/bar")
+        .when()
+        .get("/streaming/account/6921042/full")
+        .then()
+        .statusCode(200)
+        .contentType("application/vnd.bose.streaming-v1.2+xml")
+        .header("METHOD_NAME", "getFullAccount")
+        .extract()
+        .body()
+        .asString();
 
     assertThat(
         responseXml,
@@ -549,15 +548,13 @@ class UeberboeseExperimentalControllerTest extends TestBase {
   void getFullAccount_shouldCacheThenServeFromCache() throws Exception {
     // Given - use unique account ID that doesn't have cached file
     String testAccountId = "cache-roundtrip-test";
-    Path cacheFile =
-        Path.of("src/test/resources/test-data", "streaming-account-full-" + testAccountId + ".xml");
+    Path cacheFile = Path.of("src/test/resources/test-data", "streaming-account-full-" + testAccountId + ".xml");
 
     // Clean up cache file if exists from previous test run
     Files.deleteIfExists(cacheFile);
 
     // language=XML
-    String mockXmlResponse =
-        """
+    String mockXmlResponse = """
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <account id="cache-roundtrip-test">
           <accountStatus>ACTIVE</accountStatus>
@@ -575,17 +572,16 @@ class UeberboeseExperimentalControllerTest extends TestBase {
                     .withBody(mockXmlResponse)));
 
     // When - First request (cache miss)
-    String firstResponse =
-        given()
-            .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
-            .when()
-            .get("/streaming/account/" + testAccountId + "/full")
-            .then()
-            .statusCode(200)
-            .contentType("application/vnd.bose.streaming-v1.2+xml")
-            .extract()
-            .body()
-            .asString();
+    String firstResponse = given()
+        .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
+        .when()
+        .get("/streaming/account/" + testAccountId + "/full")
+        .then()
+        .statusCode(200)
+        .contentType("application/vnd.bose.streaming-v1.2+xml")
+        .extract()
+        .body()
+        .asString();
 
     // Then - Verify proxy was called once
     wireMockServer.verify(
@@ -595,17 +591,16 @@ class UeberboeseExperimentalControllerTest extends TestBase {
     assertTrue(Files.exists(cacheFile), "Cache file should exist after first request");
 
     // When - Second request (cache hit)
-    String secondResponse =
-        given()
-            .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
-            .when()
-            .get("/streaming/account/" + testAccountId + "/full")
-            .then()
-            .statusCode(200)
-            .contentType("application/vnd.bose.streaming-v1.2+xml")
-            .extract()
-            .body()
-            .asString();
+    String secondResponse = given()
+        .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
+        .when()
+        .get("/streaming/account/" + testAccountId + "/full")
+        .then()
+        .statusCode(200)
+        .contentType("application/vnd.bose.streaming-v1.2+xml")
+        .extract()
+        .body()
+        .asString();
 
     // Then - Verify proxy was STILL only called once (not twice)
     wireMockServer.verify(
@@ -621,8 +616,7 @@ class UeberboeseExperimentalControllerTest extends TestBase {
   @Test
   void updatePreset_shouldUpdatePresetSuccessfully() {
     // language=XML
-    String requestXml =
-        """
+    String requestXml = """
         <?xml version="1.0" encoding="UTF-8" ?>
         <preset buttonNumber="2">
           <sourceid>19989643</sourceid>
@@ -634,29 +628,27 @@ class UeberboeseExperimentalControllerTest extends TestBase {
         </preset>""";
 
     // Extract the response for XML comparison
-    String actualXml =
-        given()
-            .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
-            .header("User-agent", "Bose_Lisa/27.0.6")
-            .header("Authorization", "Bearer mockToken123")
-            .header("Content-type", "application/vnd.bose.streaming-v1.2+xml")
-            .body(requestXml)
-            .when()
-            .put("/streaming/account/6921042/device/587A628A4042/preset/2")
-            .then()
-            .statusCode(200)
-            .contentType("application/vnd.bose.streaming-v1.2+xml")
-            .header(
-                "Location",
-                containsString(
-                    "http://streamingqa.bose.com/account/6921042/device/587A628A4042/preset/2"))
-            .extract()
-            .body()
-            .asString();
+    String actualXml = given()
+        .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
+        .header("User-agent", "Bose_Lisa/27.0.6")
+        .header("Authorization", "Bearer mockToken123")
+        .header("Content-type", "application/vnd.bose.streaming-v1.2+xml")
+        .body(requestXml)
+        .when()
+        .put("/streaming/account/6921042/device/587A628A4042/preset/2")
+        .then()
+        .statusCode(200)
+        .contentType("application/vnd.bose.streaming-v1.2+xml")
+        .header(
+            "Location",
+            containsString(
+                "http://streamingqa.bose.com/account/6921042/device/587A628A4042/preset/2"))
+        .extract()
+        .body()
+        .asString();
 
     // language=XML
-    String expectedXml =
-        """
+    String expectedXml = """
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <preset buttonNumber="2">
           <containerArt>https://image-cdn-ak.spotifycdn.com/image/ab67706c0000da84993ee084406c4089ad8f4b2a</containerArt>
@@ -690,8 +682,7 @@ class UeberboeseExperimentalControllerTest extends TestBase {
     // Given - presetRepository is injected via TestBase
 
     // language=XML
-    String requestXml =
-        """
+    String requestXml = """
         <?xml version="1.0" encoding="UTF-8" ?>
         <preset buttonNumber="3">
           <sourceid>19989643</sourceid>
@@ -713,8 +704,7 @@ class UeberboeseExperimentalControllerTest extends TestBase {
         .statusCode(200);
 
     // Then - verify preset was saved to database
-    Optional<Preset> saved =
-        presetRepository.findByAccountIdAndDeviceIdAndButtonNumber("testaccount", "testdevice", 3);
+    Optional<Preset> saved = presetRepository.findByAccountIdAndDeviceIdAndButtonNumber("testaccount", "testdevice", 3);
     assertThat(saved).isPresent();
     assertThat(saved.get().name()).isEqualTo("My Playlist");
     assertThat(saved.get().location()).isEqualTo("/playback/container/test123");
@@ -726,25 +716,23 @@ class UeberboeseExperimentalControllerTest extends TestBase {
   void updatePreset_shouldUpsertExisting() {
     // Given - existing preset (presetRepository is injected via TestBase)
     var now = java.time.OffsetDateTime.now().withNano(0);
-    Preset existing =
-        Preset.builder()
-            .accountId("testaccount2")
-            .deviceId("testdevice2")
-            .buttonNumber(1)
-            .name("Old Name")
-            .location("/old/location")
-            .sourceId("old-source")
-            .containerArt("https://example.org/old.png")
-            .contentItemType("stationurl")
-            .createdOn(now)
-            .updatedOn(now)
-            .build();
+    Preset existing = Preset.builder()
+        .accountId("testaccount2")
+        .deviceId("testdevice2")
+        .buttonNumber(1)
+        .name("Old Name")
+        .location("/old/location")
+        .sourceId("old-source")
+        .containerArt("https://example.org/old.png")
+        .contentItemType("stationurl")
+        .createdOn(now)
+        .updatedOn(now)
+        .build();
     Preset saved = presetRepository.save(existing);
     Long existingId = saved.id();
 
     // language=XML
-    String requestXml =
-        """
+    String requestXml = """
         <?xml version="1.0" encoding="UTF-8" ?>
         <preset buttonNumber="1">
           <sourceid>new-source</sourceid>
@@ -766,9 +754,8 @@ class UeberboeseExperimentalControllerTest extends TestBase {
         .statusCode(200);
 
     // Then - verify preset was updated (same ID)
-    Optional<Preset> updated =
-        presetRepository.findByAccountIdAndDeviceIdAndButtonNumber(
-            "testaccount2", "testdevice2", 1);
+    Optional<Preset> updated = presetRepository.findByAccountIdAndDeviceIdAndButtonNumber(
+        "testaccount2", "testdevice2", 1);
     assertThat(updated).isPresent();
     assertThat(updated.get().id()).isEqualTo(existingId); // Same ID
     assertThat(updated.get().name()).isEqualTo("Updated Name");
@@ -779,27 +766,25 @@ class UeberboeseExperimentalControllerTest extends TestBase {
   @Test
   void getSoftwareUpdate_shouldReturnEmptyUpdateLocation() {
     // language=XML
-    String expectedXml =
-        """
+    String expectedXml = """
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <software_update>
           <softwareUpdateLocation></softwareUpdateLocation>
         </software_update>
         """;
 
-    String actualXml =
-        given()
-            .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
-            .header("User-agent", "Bose_Lisa/27.0.6")
-            .header("Authorization", "Bearer mockToken123")
-            .when()
-            .get("/streaming/software/update/account/6921042")
-            .then()
-            .statusCode(200)
-            .contentType("application/vnd.bose.streaming-v1.2+xml")
-            .extract()
-            .body()
-            .asString();
+    String actualXml = given()
+        .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
+        .header("User-agent", "Bose_Lisa/27.0.6")
+        .header("Authorization", "Bearer mockToken123")
+        .when()
+        .get("/streaming/software/update/account/6921042")
+        .then()
+        .statusCode(200)
+        .contentType("application/vnd.bose.streaming-v1.2+xml")
+        .extract()
+        .body()
+        .asString();
 
     assertThat(
         actualXml,
@@ -810,49 +795,45 @@ class UeberboeseExperimentalControllerTest extends TestBase {
 
   @Test
   void updateDevice_shouldUpdateDeviceNameSuccessfully() {
-    var existingDevice =
-        Device.builder()
-            .deviceId("587A628A4042")
-            .name("Old Name")
-            .ipAddress("192.168.178.33")
-            .firstSeen(OffsetDateTime.parse("2018-08-11T08:55:25.000+00:00"))
-            .lastSeen(OffsetDateTime.parse("2025-01-01T10:00:00.000+00:00"))
-            .version(null)
-            .build();
+    var existingDevice = Device.builder()
+        .deviceId("587A628A4042")
+        .name("Old Name")
+        .ipAddress("192.168.178.33")
+        .firstSeen(OffsetDateTime.parse("2018-08-11T08:55:25.000+00:00"))
+        .lastSeen(OffsetDateTime.parse("2025-01-01T10:00:00.000+00:00"))
+        .version(null)
+        .build();
     deviceRepository.save(existingDevice);
 
     // language=XML
-    String requestXml =
-        """
+    String requestXml = """
         <?xml version="1.0" encoding="UTF-8" ?>
         <device deviceid="587A628A4042">
           <name>Test Device</name>
           <macaddress>587A628A4042</macaddress>
         </device>""";
 
-    String actualXml =
-        given()
-            .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
-            .header("User-agent", "Bose_Lisa/27.0.6")
-            .header("Authorization", "Bearer mockToken123")
-            .header("Content-type", "application/vnd.bose.streaming-v1.2+xml")
-            .body(requestXml)
-            .when()
-            .put("/streaming/account/6921042/device/587A628A4042")
-            .then()
-            .statusCode(200)
-            .contentType("application/vnd.bose.streaming-v1.2+xml")
-            .header(
-                "Location",
-                containsString("http://streamingqa.bose.com/account/6921042/device/587A628A4042"))
-            .header("METHOD_NAME", "updateDevice")
-            .extract()
-            .body()
-            .asString();
+    String actualXml = given()
+        .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
+        .header("User-agent", "Bose_Lisa/27.0.6")
+        .header("Authorization", "Bearer mockToken123")
+        .header("Content-type", "application/vnd.bose.streaming-v1.2+xml")
+        .body(requestXml)
+        .when()
+        .put("/streaming/account/6921042/device/587A628A4042")
+        .then()
+        .statusCode(200)
+        .contentType("application/vnd.bose.streaming-v1.2+xml")
+        .header(
+            "Location",
+            containsString("http://streamingqa.bose.com/account/6921042/device/587A628A4042"))
+        .header("METHOD_NAME", "updateDevice")
+        .extract()
+        .body()
+        .asString();
 
     // language=XML
-    String expectedXml =
-        """
+    String expectedXml = """
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <device deviceid="587A628A4042">
           <createdOn>2018-08-11T08:55:25.000+00:00</createdOn>
@@ -877,37 +858,34 @@ class UeberboeseExperimentalControllerTest extends TestBase {
     // No existing device - will trigger the orElseGet branch
 
     // language=XML
-    String requestXml =
-        """
+    String requestXml = """
         <?xml version="1.0" encoding="UTF-8" ?>
         <device deviceid="NEW_DEVICE_123">
           <name>New Device</name>
           <macaddress>NEW_DEVICE_123</macaddress>
         </device>""";
 
-    String actualXml =
-        given()
-            .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
-            .header("User-agent", "Bose_Lisa/27.0.6")
-            .header("Authorization", "Bearer mockToken123")
-            .header("Content-type", "application/vnd.bose.streaming-v1.2+xml")
-            .body(requestXml)
-            .when()
-            .put("/streaming/account/6921042/device/NEW_DEVICE_123")
-            .then()
-            .statusCode(200)
-            .contentType("application/vnd.bose.streaming-v1.2+xml")
-            .header(
-                "Location",
-                containsString("http://streamingqa.bose.com/account/6921042/device/NEW_DEVICE_123"))
-            .header("METHOD_NAME", "updateDevice")
-            .extract()
-            .body()
-            .asString();
+    String actualXml = given()
+        .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
+        .header("User-agent", "Bose_Lisa/27.0.6")
+        .header("Authorization", "Bearer mockToken123")
+        .header("Content-type", "application/vnd.bose.streaming-v1.2+xml")
+        .body(requestXml)
+        .when()
+        .put("/streaming/account/6921042/device/NEW_DEVICE_123")
+        .then()
+        .statusCode(200)
+        .contentType("application/vnd.bose.streaming-v1.2+xml")
+        .header(
+            "Location",
+            containsString("http://streamingqa.bose.com/account/6921042/device/NEW_DEVICE_123"))
+        .header("METHOD_NAME", "updateDevice")
+        .extract()
+        .body()
+        .asString();
 
     // language=XML
-    String expectedXml =
-        """
+    String expectedXml = """
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <device deviceid="NEW_DEVICE_123">
           <createdOn>${xmlunit.isDateTime}</createdOn>
@@ -958,8 +936,7 @@ class UeberboeseExperimentalControllerTest extends TestBase {
   @Test
   void customerSupport_shouldAcceptDeviceDiagnosticData() {
     // language=XML
-    String requestXml =
-        """
+    String requestXml = """
         <?xml version="1.0" encoding="UTF-8" ?>
         <device-data>
           <device id="587A628A4042">
@@ -1003,19 +980,18 @@ class UeberboeseExperimentalControllerTest extends TestBase {
   @Test
   void deletePreset_shouldRemovePresetSuccessfully() {
     // Given - Create a preset first
-    Preset preset =
-        Preset.builder()
-            .accountId("6921042")
-            .deviceId("587A628A4042")
-            .buttonNumber(1)
-            .containerArt("http://example.com/art.png")
-            .contentItemType("stationurl")
-            .location("/v1/playback/station/s12345")
-            .name("Test Station")
-            .sourceId("19989342")
-            .createdOn(OffsetDateTime.now())
-            .updatedOn(OffsetDateTime.now())
-            .build();
+    Preset preset = Preset.builder()
+        .accountId("6921042")
+        .deviceId("587A628A4042")
+        .buttonNumber(1)
+        .containerArt("http://example.com/art.png")
+        .contentItemType("stationurl")
+        .location("/v1/playback/station/s12345")
+        .name("Test Station")
+        .sourceId("19989342")
+        .createdOn(OffsetDateTime.now())
+        .updatedOn(OffsetDateTime.now())
+        .build();
     presetRepository.save(preset);
 
     // When - Delete the preset
@@ -1029,37 +1005,35 @@ class UeberboeseExperimentalControllerTest extends TestBase {
         .header("Content-Type", "application/vnd.bose.streaming-v1.2+xml");
 
     // Then - Verify preset was deleted from database
-    Optional<Preset> deleted =
-        presetRepository.findByAccountIdAndDeviceIdAndButtonNumber("6921042", "587A628A4042", 1);
+    Optional<Preset> deleted = presetRepository.findByAccountIdAndDeviceIdAndButtonNumber("6921042", "587A628A4042", 1);
     assertThat(deleted).isEmpty();
   }
 
   @Test
   void deletePreset_shouldReturn404WhenPresetNotFound() {
     // When - Try to delete non-existent preset
-    String actualXml =
-        given()
-            .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
-            .header("Authorization", "Bearer mockBearerTokenABC123xyz=")
-            .when()
-            .delete("/streaming/account/6921042/device/587A628A4042/preset/5")
-            .then()
-            .statusCode(404)
-            .header("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
-            .extract()
-            .asString();
+    String actualXml = given()
+        .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
+        .header("Authorization", "Bearer mockBearerTokenABC123xyz=")
+        .when()
+        .delete("/streaming/account/6921042/device/587A628A4042/preset/5")
+        .then()
+        .statusCode(404)
+        .header("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
+        .extract()
+        .asString();
 
     // Then - Verify error response XML
     assertThat(
         actualXml,
         isSimilarTo(
-                """
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <status>
-          <message>Not found</message>
-          <status-code>404</status-code>
-        </status>
-        """)
+            """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <status>
+                  <message>Not found</message>
+                  <status-code>404</status-code>
+                </status>
+                """)
             .ignoreWhitespace()
             .withDifferenceEvaluator(new PlaceholderDifferenceEvaluator()));
   }
@@ -1068,41 +1042,38 @@ class UeberboeseExperimentalControllerTest extends TestBase {
   void getPreset_shouldReturnPreset() {
     // Given - Create a preset in the database
     var now = OffsetDateTime.now().withNano(0);
-    Preset preset4 =
-        Preset.builder()
-            .accountId("6921042")
-            .deviceId("587A628A4042")
-            .buttonNumber(4)
-            .name("Seasonal Mix")
-            .location("/playback/container/c3BvdGlmeTpwbGF5bGlzdDoyd0JCOGIzUWhDWXd5T0d2dE9id3dI")
-            .sourceId("19989621")
-            .containerArt("https://mosaic.scdn.co/300/mockimageurl")
-            .contentItemType("tracklisturl")
-            .createdOn(OffsetDateTime.parse("2018-11-26T18:47:06.000+00:00"))
-            .updatedOn(OffsetDateTime.parse("2022-11-17T19:35:37.000+00:00"))
-            .build();
+    Preset preset4 = Preset.builder()
+        .accountId("6921042")
+        .deviceId("587A628A4042")
+        .buttonNumber(4)
+        .name("Seasonal Mix")
+        .location("/playback/container/c3BvdGlmeTpwbGF5bGlzdDoyd0JCOGIzUWhDWXd5T0d2dE9id3dI")
+        .sourceId("19989621")
+        .containerArt("https://mosaic.scdn.co/300/mockimageurl")
+        .contentItemType("tracklisturl")
+        .createdOn(OffsetDateTime.parse("2018-11-26T18:47:06.000+00:00"))
+        .updatedOn(OffsetDateTime.parse("2022-11-17T19:35:37.000+00:00"))
+        .build();
     presetRepository.save(preset4);
 
     // When / Then
-    String actualXml =
-        given()
-            .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
-            .header("User-agent", "Bose_Lisa/27.0.6")
-            .header(
-                "Authorization",
-                "Bearer nRBCU6Iaiuu0MV498UmdWZv7Y1/qtwtEhLaERcp5C1jBxCDJjTS21UJItr2xw3RYSx808JkS9pOdUVGgP4FAPDd5wpT8MPVgmKtDjztBxRn1lCq6FH/riDIMW0OD9SyP")
-            .when()
-            .get("/streaming/account/6921042/device/587A628A4042/preset/4")
-            .then()
-            .statusCode(200)
-            .contentType("application/vnd.bose.streaming-v1.2+xml")
-            .extract()
-            .body()
-            .asString();
+    String actualXml = given()
+        .header("Accept", "application/vnd.bose.streaming-v1.2+xml")
+        .header("User-agent", "Bose_Lisa/27.0.6")
+        .header(
+            "Authorization",
+            "Bearer nRBCU6Iaiuu0MV498UmdWZv7Y1/qtwtEhLaERcp5C1jBxCDJjTS21UJItr2xw3RYSx808JkS9pOdUVGgP4FAPDd5wpT8MPVgmKtDjztBxRn1lCq6FH/riDIMW0OD9SyP")
+        .when()
+        .get("/streaming/account/6921042/device/587A628A4042/preset/4")
+        .then()
+        .statusCode(200)
+        .contentType("application/vnd.bose.streaming-v1.2+xml")
+        .extract()
+        .body()
+        .asString();
 
     // language=XML
-    String expectedXml =
-        """
+    String expectedXml = """
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <preset buttonNumber="4">
           <containerArt>https://mosaic.scdn.co/300/mockimageurl</containerArt>

--- a/ueberboese-api.yaml
+++ b/ueberboese-api.yaml
@@ -1989,6 +1989,50 @@ components:
           type: string
           description: Space-separated list of granted scopes
           example: "playlist-read-private playlist-read-collaborative streaming user-library-read user-library-modify playlist-modify-private playlist-modify-public user-read-email user-read-private user-top-read"
+    
+    ProviderSetting:
+      type: object
+      description: Provider-specific settings
+      xml:
+        name: providerSetting
+      properties:
+        boseId:
+          type: integer
+          description: Bose account identifier associated with the provider settings
+          xml:
+            attribute: true
+          example: 6921042
+        keyName:
+          type: string
+          description: Name of the provider setting key
+          xml:
+            attribute: true
+          example: "exampleKey"
+        value:
+          type: boolean
+          description: Value of the provider setting
+          xml:
+            attribute: true
+          example: true
+        providerId:
+          type: integer
+          description: Identifier of the provider associated with the settings
+          xml:
+            attribute: true
+          example: 15
+
+    ProviderSettingsContainer:
+      type: object
+      description: Container for provider settings
+      xml:
+        name: providerSettings
+      properties:
+        providerSetting:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderSetting'
+          xml:
+            wrapped: false
 
     FullAccountResponse:
       type: object
@@ -2025,6 +2069,8 @@ components:
           example: "de"
         sources:
           $ref: '#/components/schemas/SourcesContainer'
+        providerSettings:
+          $ref: '#/components/schemas/ProviderSettingsContainer'
 
     DevicesContainer:
       type: object
@@ -2038,7 +2084,7 @@ components:
             $ref: '#/components/schemas/Device'
           xml:
             wrapped: false
-
+    
     Device:
       type: object
       description: Device information


### PR DESCRIPTION
Hi.

This is a clean pull request without my changes.

On my SoundTouch 20 device I get providerSettings in the full account response so I added it to the spec and updated the test.

```
    <providerSettings>
        <providerSetting>
            <boseId>3932343</boseId>
            <keyName>ELIGIBLE_FOR_TRIAL</keyName>
            <value>true</value>
            <providerId>14</providerId>
        </providerSetting>
    </providerSettings>

```