### PR TITLE
feat: auto-provision never-paired speakers and fix anonymous TuneIn

### DIFF
--- a/docs/redirect-speaker-via-envswitch.md
+++ b/docs/redirect-speaker-via-envswitch.md
@@ -1,0 +1,70 @@
+---
+layout: page
+title: Redirect speaker via port 17000 (envswitch)
+description: How to redirect a SoundTouch speaker's cloud URLs to the Überböse API using the built-in envswitch CLI on port 17000 — an alternative to editing the config file via SSH.
+---
+
+On some SoundTouch devices, port **17000** exposes a built-in CLI called `envswitch` that can redirect the speaker's cloud URLs. This is an alternative to editing `/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml` via SSH, and is useful when USB stick access is difficult or unreliable.
+
+Note: this covers the URL redirect step only. For the full advanced setup (Sources.xml, SSH access to persistent storage), the [USB stick method](advanced-set-up.md) is still required.
+
+This was confirmed working on a **SoundTouch 10** (firmware `27.0.6.46330.5043500`).
+
+## Step 1: Confirm the speaker is reachable
+
+```bash
+curl -s http://<SPEAKER_IP>:8090/info | grep margeURL
+```
+
+Expected output before setup:
+```
+<margeURL>https://streaming.bose.com</margeURL>
+```
+
+## Step 2: Confirm port 17000 is available
+
+```bash
+nmap -p 17000 <SPEAKER_IP>
+```
+
+If the port shows `open`, the envswitch CLI is available.
+
+## Step 3: Redirect the speaker to your Überböse API
+
+```bash
+printf "envswitch boseurls set http://<UEBERBOESE_IP>:<PORT> http://<UEBERBOESE_IP>:<PORT>\r\n" \
+  | nc -w 3 <SPEAKER_IP> 17000
+```
+
+Expected response:
+```
+->Setting Bose Server URLs to http://<UEBERBOESE_IP>:<PORT> and http://<UEBERBOESE_IP>:<PORT>
+->OK
+```
+
+The two arguments set the **marge** (streaming) URL and the **stats** URL respectively.
+
+## Step 4: Power cycle the speaker
+
+The envswitch change does **not** take effect immediately. You must physically unplug the speaker, wait 5 seconds, and plug it back in.
+
+There is no software reboot command available on port 17000.
+
+## Step 5: Confirm the change
+
+After the speaker comes back up:
+
+```bash
+curl -s http://<SPEAKER_IP>:8090/info | grep margeURL
+```
+
+Expected output after setup:
+```
+<margeURL>http://<UEBERBOESE_IP>:<PORT></margeURL>
+```
+
+## Notes
+
+- Port 23 (telnet) and port 22 (SSH) remain **closed** — the envswitch method gives you URL redirection only, not a shell.
+- If port 17000 is not open, fall back to the [USB stick method](advanced-set-up.md).
+- The POWER key via the SoundTouch HTTP API (`POST /key`) only toggles standby — it does **not** trigger a real reboot.

--- a/src/main/java/com/github/juliusd/ueberboeseapi/BmxController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/BmxController.java
@@ -107,11 +107,9 @@ public class BmxController implements BmxApi {
     log.info("Refreshing TuneIn token");
 
     try {
-      String refreshToken =
-          bmxTokenRequestApiDto != null ? bmxTokenRequestApiDto.getRefreshToken() : null;
+      String refreshToken = bmxTokenRequestApiDto.getRefreshToken();
       if (refreshToken == null || refreshToken.isEmpty()) {
-        refreshToken = java.util.UUID.randomUUID().toString();
-        log.info("No refresh token provided, issuing new anonymous TuneIn token");
+        return ResponseEntity.badRequest().build();
       }
 
       BmxTokenResponseApiDto response = bmxService.refreshTuneInToken(refreshToken);

--- a/src/main/java/com/github/juliusd/ueberboeseapi/BmxController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/BmxController.java
@@ -107,9 +107,11 @@ public class BmxController implements BmxApi {
     log.info("Refreshing TuneIn token");
 
     try {
-      String refreshToken = bmxTokenRequestApiDto.getRefreshToken();
+      String refreshToken =
+          bmxTokenRequestApiDto != null ? bmxTokenRequestApiDto.getRefreshToken() : null;
       if (refreshToken == null || refreshToken.isEmpty()) {
-        return ResponseEntity.badRequest().build();
+        refreshToken = java.util.UUID.randomUUID().toString();
+        log.info("No refresh token provided, issuing new anonymous TuneIn token");
       }
 
       BmxTokenResponseApiDto response = bmxService.refreshTuneInToken(refreshToken);

--- a/src/main/java/com/github/juliusd/ueberboeseapi/NoiseController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/NoiseController.java
@@ -1,5 +1,6 @@
 package com.github.juliusd.ueberboeseapi;
 
+import com.github.juliusd.ueberboeseapi.generated.dtos.AccountResponseApiDto;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.InputStream;
@@ -16,30 +17,21 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Slf4j
 public class NoiseController {
 
-  /**
-   * Handles the speaker's initial registration call. Never-paired devices call GET
-   * /?serialnumber=<SN> to discover their accountId. We return the serial number itself as the
-   * accountId so the speaker stores it as margeAccountUUID and then calls GET
-   * /streaming/account/{id}/full to fetch its sources.
-   */
   @GetMapping(
       value = "/",
       params = "serialnumber",
       produces = "application/vnd.bose.streaming-v1.2+xml")
-  public ResponseEntity<byte[]> indexWithSerialNumber(
+  public ResponseEntity<AccountResponseApiDto> indexWithSerialNumber(
       @RequestParam("serialnumber") String serialNumber) {
-    String xml =
-        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
-            + "<account id=\""
-            + serialNumber
-            + "\">"
-            + "<accountStatus>ACTIVE</accountStatus>"
-            + "<mode>global</mode>"
-            + "<preferredLanguage>en</preferredLanguage>"
-            + "</account>";
+    AccountResponseApiDto account =
+        new AccountResponseApiDto()
+            .id(serialNumber)
+            .accountStatus("ACTIVE")
+            .mode("global")
+            .preferredLanguage("en");
     return ResponseEntity.ok()
         .header("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
-        .body(xml.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        .body(account);
   }
 
   @GetMapping("/")

--- a/src/main/java/com/github/juliusd/ueberboeseapi/NoiseController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/NoiseController.java
@@ -10,10 +10,37 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @Slf4j
 public class NoiseController {
+
+  /**
+   * Handles the speaker's initial registration call. Never-paired devices call GET
+   * /?serialnumber=<SN> to discover their accountId. We return the serial number itself as the
+   * accountId so the speaker stores it as margeAccountUUID and then calls GET
+   * /streaming/account/{id}/full to fetch its sources.
+   */
+  @GetMapping(
+      value = "/",
+      params = "serialnumber",
+      produces = "application/vnd.bose.streaming-v1.2+xml")
+  public ResponseEntity<byte[]> indexWithSerialNumber(
+      @RequestParam("serialnumber") String serialNumber) {
+    String xml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            + "<account id=\""
+            + serialNumber
+            + "\">"
+            + "<accountStatus>ACTIVE</accountStatus>"
+            + "<mode>global</mode>"
+            + "<preferredLanguage>en</preferredLanguage>"
+            + "</account>";
+    return ResponseEntity.ok()
+        .header("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
+        .body(xml.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+  }
 
   @GetMapping("/")
   public ResponseEntity<Void> index(HttpServletRequest request) {

--- a/src/main/java/com/github/juliusd/ueberboeseapi/UeberboeseController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/UeberboeseController.java
@@ -33,6 +33,7 @@ import com.github.juliusd.ueberboeseapi.service.AccountDataService;
 import com.github.juliusd.ueberboeseapi.service.DeviceTrackingService;
 import com.github.juliusd.ueberboeseapi.service.DeviceTrackingService.PowerOnData;
 import com.github.juliusd.ueberboeseapi.service.FullAccountService;
+import com.github.juliusd.ueberboeseapi.service.SpeakerProvisioningService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.URI;
@@ -61,6 +62,7 @@ public class UeberboeseController implements DefaultApi {
   private final PresetMapper presetMapper;
   private final DeviceService deviceService;
   private final DeviceRepository deviceRepository;
+  private final SpeakerProvisioningService speakerProvisioningService;
 
   @Autowired private HttpServletRequest request;
 
@@ -505,6 +507,7 @@ public class UeberboeseController implements DefaultApi {
             .productSerialNumber(product.getSerialnumber());
       }
       deviceTrackingService.recordDevicePowerOn(powerOnDataBuilder.build());
+      speakerProvisioningService.provisionIfNeeded(deviceId, ipAddress);
 
       log.info("Successfully processed power_on for device: {} at IP: {}", deviceId, ipAddress);
 

--- a/src/main/java/com/github/juliusd/ueberboeseapi/UeberboeseController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/UeberboeseController.java
@@ -43,6 +43,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -65,6 +66,9 @@ public class UeberboeseController implements DefaultApi {
   private final SpeakerProvisioningService speakerProvisioningService;
 
   @Autowired private HttpServletRequest request;
+
+  @Value("${ueberboese.auto-provisioning.enabled:true}")
+  private boolean autoProvisioningEnabled;
 
   @Override
   public ResponseEntity<RecentItemResponseApiDto> addRecentItem(
@@ -507,7 +511,9 @@ public class UeberboeseController implements DefaultApi {
             .productSerialNumber(product.getSerialnumber());
       }
       deviceTrackingService.recordDevicePowerOn(powerOnDataBuilder.build());
-      speakerProvisioningService.provisionIfNeeded(deviceId, ipAddress);
+      if (autoProvisioningEnabled) {
+        speakerProvisioningService.provisionIfNeeded(deviceId, ipAddress);
+      }
 
       log.info("Successfully processed power_on for device: {} at IP: {}", deviceId, ipAddress);
 

--- a/src/main/java/com/github/juliusd/ueberboeseapi/service/SpeakerProvisioningService.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/service/SpeakerProvisioningService.java
@@ -1,0 +1,75 @@
+package com.github.juliusd.ueberboeseapi.service;
+
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Automatically provisions never-paired speakers on power-on. When a speaker reports power_on with
+ * an empty margeAccountUUID, this service calls POST /setMargeAccount on the speaker using its own
+ * MAC address as the accountId. This allows factory-reset or never-paired devices to work with the
+ * Überböse API without any manual intervention.
+ *
+ * <p>Discovery: POST http://speaker:8090/setMargeAccount with payload {@code
+ * <PairDeviceWithAccount><accountId>MAC</accountId><userAuthToken>any</userAuthToken></PairDeviceWithAccount>}
+ * sets the margeAccountUUID on the speaker at runtime, persisting across reboots.
+ */
+@Service
+@Slf4j
+public class SpeakerProvisioningService {
+
+  private static final int SETTLE_DELAY_MS = 3000;
+
+  private final RestClient restClient = RestClient.create();
+
+  public void provisionIfNeeded(String deviceId, String ipAddress) {
+    CompletableFuture.runAsync(
+        () -> {
+          try {
+            Thread.sleep(SETTLE_DELAY_MS);
+            if (hasMargeAccountUUID(ipAddress)) {
+              return;
+            }
+            setMargeAccount(deviceId, ipAddress);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } catch (Exception e) {
+            log.warn(
+                "Failed to provision device {} at {}: {}", deviceId, ipAddress, e.getMessage());
+          }
+        });
+  }
+
+  private boolean hasMargeAccountUUID(String ipAddress) {
+    try {
+      String info =
+          restClient.get().uri("http://" + ipAddress + ":8090/info").retrieve().body(String.class);
+      boolean empty =
+          info == null
+              || info.contains("<margeAccountUUID></margeAccountUUID>")
+              || info.contains("<margeAccountUUID/>");
+      return !empty;
+    } catch (Exception e) {
+      log.debug("Could not read /info from {}: {}", ipAddress, e.getMessage());
+      return true;
+    }
+  }
+
+  private void setMargeAccount(String deviceId, String ipAddress) {
+    String payload =
+        "<PairDeviceWithAccount><accountId>"
+            + deviceId
+            + "</accountId><userAuthToken>SoundTouchHybrid</userAuthToken></PairDeviceWithAccount>";
+
+    restClient
+        .post()
+        .uri("http://" + ipAddress + ":8090/setMargeAccount")
+        .header("Content-Type", "application/xml")
+        .body(payload)
+        .retrieve()
+        .toBodilessEntity();
+
+    log.info("Provisioned margeAccountUUID='{}' on device at {}", deviceId, ipAddress);
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,6 +25,10 @@ ueberboese.oauth.enabled=false
 # Maximum number of events to keep per device in memory (default: 50)
 ueberboese.events.max-events-per-device=50
 
+# Auto-provisioning configuration
+# Set to false to disable automatic provisioning of never-paired speakers on power_on
+ueberboese.auto-provisioning.enabled=true
+
 ueberboese.data-directory=/data
 
 # Management API Security configuration

--- a/ueberboese-api.yaml
+++ b/ueberboese-api.yaml
@@ -3485,9 +3485,6 @@ components:
     BmxTokenRequest:
       type: object
       description: Token refresh request
-      required:
-        - grant_type
-        - refresh_token
       properties:
         grant_type:
           type: string

--- a/ueberboese-api.yaml
+++ b/ueberboese-api.yaml
@@ -12,6 +12,40 @@ info:
     - **bmx**: API for streaming radio services (TuneIn, Custom Stations, etc.)
   version: 1.2.0
 paths:
+  /:
+    get:
+      summary: Speaker account registration
+      description: |
+        Initial registration call made by never-paired (factory-reset) devices.
+        When a speaker calls `GET /?serialnumber=<SN>`, this endpoint returns a minimal
+        account XML so the device can store its accountId and proceed to fetch full account data.
+        Devices that are already paired call `GET /` without a serialnumber parameter.
+      operationId: getAccountBySerialNumber
+      tags:
+        - noise
+      parameters:
+        - name: serialnumber
+          in: query
+          required: true
+          schema:
+            type: string
+          description: The device serial number, used as the accountId in the response
+          example: "0123456789AB"
+      responses:
+        '200':
+          description: Minimal account XML for device registration
+          content:
+            application/vnd.bose.streaming-v1.2+xml:
+              schema:
+                $ref: '#/components/schemas/AccountResponse'
+              example: |
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <account id="0123456789AB">
+                  <accountStatus>ACTIVE</accountStatus>
+                  <mode>global</mode>
+                  <preferredLanguage>en</preferredLanguage>
+                </account>
+
   /streaming/sourceproviders:
     get:
       summary: Get streaming source providers
@@ -2008,6 +2042,28 @@ components:
         example: "587A628A4042"
 
   schemas:
+    AccountResponse:
+      type: object
+      description: Minimal account response returned during device registration
+      xml:
+        name: account
+      properties:
+        id:
+          type: string
+          description: Account ID (serial number for never-paired devices)
+          xml:
+            attribute: true
+          example: "0123456789AB"
+        accountStatus:
+          type: string
+          example: "ACTIVE"
+        mode:
+          type: string
+          example: "global"
+        preferredLanguage:
+          type: string
+          example: "en"
+
     SourceProvidersResponse:
       type: object
       description: XML response containing list of source providers
@@ -3485,6 +3541,9 @@ components:
     BmxTokenRequest:
       type: object
       description: Token refresh request
+      required:
+        - grant_type
+        - refresh_token
       properties:
         grant_type:
           type: string


### PR DESCRIPTION
## Summary

Fixes the core problem for factory-reset or never-paired devices after the Bose cloud shutdown (see #18). Tested on a SoundTouch 10 (firmware 27.0.6) that had never been paired with a Bose account.

- **Auto-provisioning**: New `SpeakerProvisioningService` is called on every `power_on`. It checks if the speaker has an empty `margeAccountUUID` and, if so, calls `POST /setMargeAccount` on the speaker using its own MAC as the accountId. The UUID is set at runtime and persists across reboots — no manual steps needed after initial redirect setup.

- **`GET /?serialnumber=` handler**: Never-paired devices call this on boot to discover their accountId. Now returns a minimal account XML so the speaker proceeds to fetch its full account and sources (including TuneIn).

- **Anonymous TuneIn token**: `BmxController.refreshTuneInToken` was returning `400 Bad Request` when `refreshToken` was absent or empty (first-use on a never-paired device). Now issues a fresh UUID token instead.

- **TuneIn credential fix**: `buildMinimalAccount` was returning `credential="eyJ..."` (a literal placeholder string). Changed to `"eyJduTune="` which matches the format the speaker expects for an active TuneIn source.

- **`BmxTokenRequest` schema**: Made `grant_type` and `refresh_token` optional in the OpenAPI spec to reflect the anonymous token flow.

- **Docs**: Added `docs/redirect-speaker-via-envswitch.md` — documents the port 17000 `envswitch` method as an alternative to SSH for the margeURL redirect step. The USB/SSH method is still needed for the full advanced setup.

## Test plan

- [ ] Factory-reset / never-paired SoundTouch device redirected to Überböse API boots and registers automatically (check logs for `Provisioned margeAccountUUID`)
- [ ] `GET /?serialnumber=<SN>` returns account XML with the serial number as id
- [ ] TuneIn source appears as `READY` in `/sources` without any manual setup
- [ ] TuneIn station plays via preset button
- [ ] Existing paired devices are unaffected (provisioning skips devices that already have a UUID)