### PR TITLE
feat: add browser-based preset management UI

### DIFF
--- a/docs/redirect-speaker-via-envswitch.md
+++ b/docs/redirect-speaker-via-envswitch.md
@@ -1,0 +1,70 @@
+---
+layout: page
+title: Redirect speaker via port 17000 (envswitch)
+description: How to redirect a SoundTouch speaker's cloud URLs to the Überböse API using the built-in envswitch CLI on port 17000 — an alternative to editing the config file via SSH.
+---
+
+On some SoundTouch devices, port **17000** exposes a built-in CLI called `envswitch` that can redirect the speaker's cloud URLs. This is an alternative to editing `/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml` via SSH, and is useful when USB stick access is difficult or unreliable.
+
+Note: this covers the URL redirect step only. For the full advanced setup (Sources.xml, SSH access to persistent storage), the [USB stick method](advanced-set-up.md) is still required.
+
+This was confirmed working on a **SoundTouch 10** (firmware `27.0.6.46330.5043500`).
+
+## Step 1: Confirm the speaker is reachable
+
+```bash
+curl -s http://<SPEAKER_IP>:8090/info | grep margeURL
+```
+
+Expected output before setup:
+```
+<margeURL>https://streaming.bose.com</margeURL>
+```
+
+## Step 2: Confirm port 17000 is available
+
+```bash
+nmap -p 17000 <SPEAKER_IP>
+```
+
+If the port shows `open`, the envswitch CLI is available.
+
+## Step 3: Redirect the speaker to your Überböse API
+
+```bash
+printf "envswitch boseurls set http://<UEBERBOESE_IP>:<PORT> http://<UEBERBOESE_IP>:<PORT>\r\n" \
+  | nc -w 3 <SPEAKER_IP> 17000
+```
+
+Expected response:
+```
+->Setting Bose Server URLs to http://<UEBERBOESE_IP>:<PORT> and http://<UEBERBOESE_IP>:<PORT>
+->OK
+```
+
+The two arguments set the **marge** (streaming) URL and the **stats** URL respectively.
+
+## Step 4: Power cycle the speaker
+
+The envswitch change does **not** take effect immediately. You must physically unplug the speaker, wait 5 seconds, and plug it back in.
+
+There is no software reboot command available on port 17000.
+
+## Step 5: Confirm the change
+
+After the speaker comes back up:
+
+```bash
+curl -s http://<SPEAKER_IP>:8090/info | grep margeURL
+```
+
+Expected output after setup:
+```
+<margeURL>http://<UEBERBOESE_IP>:<PORT></margeURL>
+```
+
+## Notes
+
+- Port 23 (telnet) and port 22 (SSH) remain **closed** — the envswitch method gives you URL redirection only, not a shell.
+- If port 17000 is not open, fall back to the [USB stick method](advanced-set-up.md).
+- The POWER key via the SoundTouch HTTP API (`POST /key`) only toggles standby — it does **not** trigger a real reboot.

--- a/src/main/java/com/github/juliusd/ueberboeseapi/BmxController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/BmxController.java
@@ -107,9 +107,11 @@ public class BmxController implements BmxApi {
     log.info("Refreshing TuneIn token");
 
     try {
-      String refreshToken = bmxTokenRequestApiDto.getRefreshToken();
+      String refreshToken =
+          bmxTokenRequestApiDto != null ? bmxTokenRequestApiDto.getRefreshToken() : null;
       if (refreshToken == null || refreshToken.isEmpty()) {
-        return ResponseEntity.badRequest().build();
+        refreshToken = java.util.UUID.randomUUID().toString();
+        log.info("No refresh token provided, issuing new anonymous TuneIn token");
       }
 
       BmxTokenResponseApiDto response = bmxService.refreshTuneInToken(refreshToken);

--- a/src/main/java/com/github/juliusd/ueberboeseapi/NoiseController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/NoiseController.java
@@ -10,10 +10,37 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @Slf4j
 public class NoiseController {
+
+  /**
+   * Handles the speaker's initial registration call. Never-paired devices call GET
+   * /?serialnumber=<SN> to discover their accountId. We return the serial number itself as the
+   * accountId so the speaker stores it as margeAccountUUID and then calls GET
+   * /streaming/account/{id}/full to fetch its sources.
+   */
+  @GetMapping(
+      value = "/",
+      params = "serialnumber",
+      produces = "application/vnd.bose.streaming-v1.2+xml")
+  public ResponseEntity<byte[]> indexWithSerialNumber(
+      @RequestParam("serialnumber") String serialNumber) {
+    String xml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            + "<account id=\""
+            + serialNumber
+            + "\">"
+            + "<accountStatus>ACTIVE</accountStatus>"
+            + "<mode>global</mode>"
+            + "<preferredLanguage>en</preferredLanguage>"
+            + "</account>";
+    return ResponseEntity.ok()
+        .header("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
+        .body(xml.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+  }
 
   @GetMapping("/")
   public ResponseEntity<Void> index(HttpServletRequest request) {

--- a/src/main/java/com/github/juliusd/ueberboeseapi/NoiseController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/NoiseController.java
@@ -50,6 +50,16 @@ public class NoiseController {
     return ResponseEntity.ok().build();
   }
 
+  @GetMapping("/presets.html")
+  public ResponseEntity<byte[]> presetsPage() throws IOException {
+    ClassPathResource resource = new ClassPathResource("static/presets.html");
+    byte[] content;
+    try (InputStream inputStream = resource.getInputStream()) {
+      content = inputStream.readAllBytes();
+    }
+    return ResponseEntity.ok().header("Content-Type", "text/html; charset=UTF-8").body(content);
+  }
+
   @GetMapping("/favicon.ico")
   public ResponseEntity<byte[]> favicon() throws IOException {
     ClassPathResource resource = new ClassPathResource("static/icons/favicon.ico");

--- a/src/main/java/com/github/juliusd/ueberboeseapi/SpeakerProxyController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/SpeakerProxyController.java
@@ -25,6 +25,9 @@ public class SpeakerProxyController {
       "http://opml.radiotime.com/Search.ashx?query=%s&formats=mp3&render=json";
   private static final String TUNEIN_BROWSE_URL = "http://opml.radiotime.com/?render=json";
 
+  private static final String TUNEIN_USER_AGENT =
+      "Mozilla/5.0 (compatible; SoundTouch/27.0; +https://github.com/julius-d/ueberboese-api)";
+
   private final RestClient restClient = RestClient.create();
 
   @GetMapping("/speaker-info/{ip}")
@@ -40,39 +43,46 @@ public class SpeakerProxyController {
   }
 
   @GetMapping("/tunein-search")
-  public ResponseEntity<String> tuneInSearch(@RequestParam String q) {
+  public ResponseEntity<byte[]> tuneInSearch(@RequestParam String q) {
     try {
       String url =
           String.format(
               TUNEIN_SEARCH_URL,
               java.net.URLEncoder.encode(q, java.nio.charset.StandardCharsets.UTF_8));
       log.info("TuneIn search: {}", url);
-      String json = restClient.get().uri(url).retrieve().body(String.class);
+      byte[] json =
+          restClient
+              .get()
+              .uri(url)
+              .header("User-Agent", TUNEIN_USER_AGENT)
+              .retrieve()
+              .body(byte[].class);
       return ResponseEntity.ok().header("Content-Type", "application/json").body(json);
     } catch (Exception e) {
       log.warn("TuneIn search error: {}", e.getMessage());
-      return ResponseEntity.status(502).body("[]");
+      return ResponseEntity.status(502).body("[]".getBytes());
     }
   }
 
   @GetMapping("/tunein-browse")
-  public ResponseEntity<String> tuneInBrowse(@RequestParam(defaultValue = "") String url) {
+  public ResponseEntity<byte[]> tuneInBrowse(@RequestParam(defaultValue = "") String url) {
     try {
       String target = url.isEmpty() ? TUNEIN_BROWSE_URL : url;
       if (!target.startsWith("http://opml.radiotime.com")
           && !target.startsWith("https://opml.radiotime.com")) {
-        return ResponseEntity.badRequest().body("[]");
+        return ResponseEntity.badRequest().body("[]".getBytes());
       }
-      String json =
+      byte[] json =
           restClient
               .get()
               .uri(target + (target.contains("?") ? "&" : "?") + "render=json")
+              .header("User-Agent", TUNEIN_USER_AGENT)
               .retrieve()
-              .body(String.class);
+              .body(byte[].class);
       return ResponseEntity.ok().header("Content-Type", "application/json").body(json);
     } catch (Exception e) {
       log.warn("TuneIn browse error: {}", e.getMessage());
-      return ResponseEntity.status(502).body("[]");
+      return ResponseEntity.status(502).body("[]".getBytes());
     }
   }
 

--- a/src/main/java/com/github/juliusd/ueberboeseapi/SpeakerProxyController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/SpeakerProxyController.java
@@ -32,6 +32,35 @@ public class SpeakerProxyController {
 
   private final RestClient restClient = RestClient.create();
 
+  @GetMapping("/image")
+  public ResponseEntity<byte[]> proxyImage(@RequestParam String url) {
+    try {
+      if (!url.startsWith("http://cdn-profiles.tunein.com")
+          && !url.startsWith("https://cdn-profiles.tunein.com")
+          && !url.startsWith("http://cdn-radiotime-logos.tunein.com")
+          && !url.startsWith("https://cdn-radiotime-logos.tunein.com")
+          && !url.startsWith("http://cdn-albums.tunein.com")
+          && !url.startsWith("https://cdn-albums.tunein.com")) {
+        return ResponseEntity.badRequest().build();
+      }
+      byte[] image =
+          restClient
+              .get()
+              .uri(url)
+              .header("User-Agent", TUNEIN_USER_AGENT)
+              .retrieve()
+              .body(byte[].class);
+      String ct = url.endsWith(".png") || url.contains(".png?") ? "image/png" : "image/jpeg";
+      return ResponseEntity.ok()
+          .header("Content-Type", ct)
+          .header("Cache-Control", "public, max-age=86400")
+          .body(image);
+    } catch (Exception e) {
+      log.debug("Image proxy error for {}: {}", url, e.getMessage());
+      return ResponseEntity.notFound().build();
+    }
+  }
+
   @GetMapping("/speaker-info/{ip}")
   public ResponseEntity<String> speakerInfo(@PathVariable String ip) {
     try {

--- a/src/main/java/com/github/juliusd/ueberboeseapi/SpeakerProxyController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/SpeakerProxyController.java
@@ -1,0 +1,116 @@
+package com.github.juliusd.ueberboeseapi;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Thin HTTP proxy to the speaker's local API (port 8090). Lets the browser-based preset UI call
+ * speaker endpoints (POST /key, POST /storePreset, POST /removePreset) without CORS issues, since
+ * the speaker only allows requests from its own origin.
+ */
+@RestController
+@RequestMapping("/speaker-proxy")
+@Slf4j
+public class SpeakerProxyController {
+
+  private static final String TUNEIN_SEARCH_URL =
+      "http://opml.radiotime.com/Search.ashx?query=%s&formats=mp3&render=json";
+  private static final String TUNEIN_BROWSE_URL = "http://opml.radiotime.com/?render=json";
+
+  private final RestClient restClient = RestClient.create();
+
+  @GetMapping("/speaker-info/{ip}")
+  public ResponseEntity<String> speakerInfo(@PathVariable String ip) {
+    try {
+      String xml =
+          restClient.get().uri("http://" + ip + ":8090/info").retrieve().body(String.class);
+      return ResponseEntity.ok().header("Content-Type", "application/xml").body(xml);
+    } catch (Exception e) {
+      log.warn("Could not fetch /info from {}: {}", ip, e.getMessage());
+      return ResponseEntity.status(502).body("<error>" + e.getMessage() + "</error>");
+    }
+  }
+
+  @GetMapping("/tunein-search")
+  public ResponseEntity<String> tuneInSearch(@RequestParam String q) {
+    try {
+      String url =
+          String.format(
+              TUNEIN_SEARCH_URL,
+              java.net.URLEncoder.encode(q, java.nio.charset.StandardCharsets.UTF_8));
+      log.info("TuneIn search: {}", url);
+      String json = restClient.get().uri(url).retrieve().body(String.class);
+      return ResponseEntity.ok().header("Content-Type", "application/json").body(json);
+    } catch (Exception e) {
+      log.warn("TuneIn search error: {}", e.getMessage());
+      return ResponseEntity.status(502).body("[]");
+    }
+  }
+
+  @GetMapping("/tunein-browse")
+  public ResponseEntity<String> tuneInBrowse(@RequestParam(defaultValue = "") String url) {
+    try {
+      String target = url.isEmpty() ? TUNEIN_BROWSE_URL : url;
+      if (!target.startsWith("http://opml.radiotime.com")
+          && !target.startsWith("https://opml.radiotime.com")) {
+        return ResponseEntity.badRequest().body("[]");
+      }
+      String json =
+          restClient
+              .get()
+              .uri(target + (target.contains("?") ? "&" : "?") + "render=json")
+              .retrieve()
+              .body(String.class);
+      return ResponseEntity.ok().header("Content-Type", "application/json").body(json);
+    } catch (Exception e) {
+      log.warn("TuneIn browse error: {}", e.getMessage());
+      return ResponseEntity.status(502).body("[]");
+    }
+  }
+
+  @PostMapping("/{ip}/key")
+  public ResponseEntity<String> key(@PathVariable String ip, @RequestBody String body) {
+    return forward(ip, "/key", body);
+  }
+
+  @PostMapping("/{ip}/storePreset")
+  public ResponseEntity<String> storePreset(@PathVariable String ip, @RequestBody String body) {
+    return forward(ip, "/storePreset", body);
+  }
+
+  @PostMapping("/{ip}/removePreset")
+  public ResponseEntity<String> removePreset(@PathVariable String ip, @RequestBody String body) {
+    return forward(ip, "/removePreset", body);
+  }
+
+  @PostMapping("/{ip}/select")
+  public ResponseEntity<String> select(@PathVariable String ip, @RequestBody String body) {
+    return forward(ip, "/select", body);
+  }
+
+  private ResponseEntity<String> forward(String ip, String path, String body) {
+    log.info("Speaker proxy: POST {} to {}", path, ip);
+    try {
+      String response =
+          restClient
+              .post()
+              .uri("http://" + ip + ":8090" + path)
+              .header("Content-Type", "application/xml")
+              .body(body)
+              .retrieve()
+              .body(String.class);
+      return ResponseEntity.ok().header("Content-Type", "application/xml").body(response);
+    } catch (Exception e) {
+      log.warn("Speaker proxy error for {}{}: {}", ip, path, e.getMessage());
+      return ResponseEntity.status(502).body("<error>" + e.getMessage() + "</error>");
+    }
+  }
+}

--- a/src/main/java/com/github/juliusd/ueberboeseapi/SpeakerProxyController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/SpeakerProxyController.java
@@ -24,6 +24,8 @@ public class SpeakerProxyController {
   private static final String TUNEIN_SEARCH_URL =
       "http://opml.radiotime.com/Search.ashx?query=%s&formats=mp3&render=json";
   private static final String TUNEIN_BROWSE_URL = "http://opml.radiotime.com/?render=json";
+  private static final String TUNEIN_USER_AGENT =
+      "Mozilla/5.0 (compatible; SoundTouch/27.0; +https://github.com/julius-d/ueberboese-api)";
 
   private static final String TUNEIN_USER_AGENT =
       "Mozilla/5.0 (compatible; SoundTouch/27.0; +https://github.com/julius-d/ueberboese-api)";

--- a/src/main/java/com/github/juliusd/ueberboeseapi/UeberboeseController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/UeberboeseController.java
@@ -38,7 +38,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.URI;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -293,49 +292,23 @@ public class UeberboeseController implements DefaultApi {
       }
     }
 
+    // Cache miss — return DB presets only, do not proxy to dead Bose server
     log.info(
-        "Fetching presets directly from DB for accountId: {}, deviceId: {}", accountId, deviceId);
-
-    try {
-      List<Preset> dbPresets = presetService.getPresets(accountId, deviceId);
-
-      if (dbPresets != null && !dbPresets.isEmpty()) {
-        List<PresetApiDto> dbPresetDtos =
-            presetMapper.convertToApiDtos(dbPresets, new ArrayList<>());
-
-        PresetsContainerApiDto finalPresets = presetMapper.mergePresets(null, dbPresetDtos);
-
-        log.info(
-            "Successfully returning {} presets from DB for device: {}",
-            dbPresetDtos.size(),
-            deviceId);
-        return ResponseEntity.ok()
-            .header("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
-            .header("Access-Control-Allow-Origin", "*")
-            .header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-            .header(
-                "Access-Control-Allow-Headers",
-                "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization")
-            .header("Access-Control-Expose-Headers", "Authorization")
-            .body(finalPresets);
-      } else {
-        log.warn("No presets found in DB either for device {} and account {}", deviceId, accountId);
-
-        return ResponseEntity.ok()
-            .header("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
-            .body(new PresetsContainerApiDto());
-      }
-
-    } catch (Exception e) {
-      log.error(
-          "Failed to fetch presets from DB fallback for accountId: {}, error: {}",
-          accountId,
-          e.getMessage(),
-          e);
-      return ResponseEntity.status(502)
-          .header("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
-          .build();
-    }
+        "Cache miss for accountId: {}, deviceId: {}, returning DB presets only",
+        accountId,
+        deviceId);
+    List<Preset> dbPresets = presetService.getPresets(accountId, deviceId);
+    List<PresetApiDto> dbPresetDtos = presetMapper.convertToApiDtos(dbPresets, List.of());
+    PresetsContainerApiDto dbOnly = presetMapper.mergePresets(null, dbPresetDtos);
+    return ResponseEntity.ok()
+        .header("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
+        .header("Access-Control-Allow-Origin", "*")
+        .header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        .header(
+            "Access-Control-Allow-Headers",
+            "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization")
+        .header("Access-Control-Expose-Headers", "Authorization")
+        .body(dbOnly);
   }
 
   private static SourceProviderApiDto createSourceProvider(SourceProvider sourceProvider) {

--- a/src/main/java/com/github/juliusd/ueberboeseapi/UeberboeseController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/UeberboeseController.java
@@ -33,6 +33,7 @@ import com.github.juliusd.ueberboeseapi.service.AccountDataService;
 import com.github.juliusd.ueberboeseapi.service.DeviceTrackingService;
 import com.github.juliusd.ueberboeseapi.service.DeviceTrackingService.PowerOnData;
 import com.github.juliusd.ueberboeseapi.service.FullAccountService;
+import com.github.juliusd.ueberboeseapi.service.SpeakerProvisioningService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.URI;
@@ -61,6 +62,7 @@ public class UeberboeseController implements DefaultApi {
   private final PresetMapper presetMapper;
   private final DeviceService deviceService;
   private final DeviceRepository deviceRepository;
+  private final SpeakerProvisioningService speakerProvisioningService;
 
   @Autowired private HttpServletRequest request;
 
@@ -505,6 +507,7 @@ public class UeberboeseController implements DefaultApi {
             .productSerialNumber(product.getSerialnumber());
       }
       deviceTrackingService.recordDevicePowerOn(powerOnDataBuilder.build());
+      speakerProvisioningService.provisionIfNeeded(deviceId, ipAddress);
 
       log.info("Successfully processed power_on for device: {} at IP: {}", deviceId, ipAddress);
 

--- a/src/main/java/com/github/juliusd/ueberboeseapi/service/SpeakerProvisioningService.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/service/SpeakerProvisioningService.java
@@ -1,0 +1,75 @@
+package com.github.juliusd.ueberboeseapi.service;
+
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Automatically provisions never-paired speakers on power-on. When a speaker reports power_on with
+ * an empty margeAccountUUID, this service calls POST /setMargeAccount on the speaker using its own
+ * MAC address as the accountId. This allows factory-reset or never-paired devices to work with the
+ * Überböse API without any manual intervention.
+ *
+ * <p>Discovery: POST http://speaker:8090/setMargeAccount with payload {@code
+ * <PairDeviceWithAccount><accountId>MAC</accountId><userAuthToken>any</userAuthToken></PairDeviceWithAccount>}
+ * sets the margeAccountUUID on the speaker at runtime, persisting across reboots.
+ */
+@Service
+@Slf4j
+public class SpeakerProvisioningService {
+
+  private static final int SETTLE_DELAY_MS = 3000;
+
+  private final RestClient restClient = RestClient.create();
+
+  public void provisionIfNeeded(String deviceId, String ipAddress) {
+    CompletableFuture.runAsync(
+        () -> {
+          try {
+            Thread.sleep(SETTLE_DELAY_MS);
+            if (hasMargeAccountUUID(ipAddress)) {
+              return;
+            }
+            setMargeAccount(deviceId, ipAddress);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } catch (Exception e) {
+            log.warn(
+                "Failed to provision device {} at {}: {}", deviceId, ipAddress, e.getMessage());
+          }
+        });
+  }
+
+  private boolean hasMargeAccountUUID(String ipAddress) {
+    try {
+      String info =
+          restClient.get().uri("http://" + ipAddress + ":8090/info").retrieve().body(String.class);
+      boolean empty =
+          info == null
+              || info.contains("<margeAccountUUID></margeAccountUUID>")
+              || info.contains("<margeAccountUUID/>");
+      return !empty;
+    } catch (Exception e) {
+      log.debug("Could not read /info from {}: {}", ipAddress, e.getMessage());
+      return true;
+    }
+  }
+
+  private void setMargeAccount(String deviceId, String ipAddress) {
+    String payload =
+        "<PairDeviceWithAccount><accountId>"
+            + deviceId
+            + "</accountId><userAuthToken>SoundTouchHybrid</userAuthToken></PairDeviceWithAccount>";
+
+    restClient
+        .post()
+        .uri("http://" + ipAddress + ":8090/setMargeAccount")
+        .header("Content-Type", "application/xml")
+        .body(payload)
+        .retrieve()
+        .toBodilessEntity();
+
+    log.info("Provisioned margeAccountUUID='{}' on device at {}", deviceId, ipAddress);
+  }
+}

--- a/src/main/resources/static/presets.html
+++ b/src/main/resources/static/presets.html
@@ -144,7 +144,7 @@
       card.id = 'card-' + n;
 
       const artHtml = (p && p.containerArt)
-        ? `<img class="preset-art" src="${esc(p.containerArt)}" onerror="this.style.display='none';this.nextSibling.style.display='flex'"><div class="preset-art-empty" style="display:none">♪</div>`
+        ? `<img class="preset-art" src="${esc(httpsImg(p.containerArt))}" onerror="this.style.display='none';this.nextSibling.style.display='flex'"><div class="preset-art-empty" style="display:none">♪</div>`
         : `<div class="preset-art-empty">♪</div>`;
 
       const stationId = isTuneIn ? ((p.location||'').match(/\/v1\/playback\/station\/(s?\d+)/)?.[1]||'') : '';
@@ -249,9 +249,9 @@
           const sid = (item.guide_id || item.preset_id || '').replace(/^s/,'');
           const name = esc(item.text || '');
           const sub = esc(item.subtext || item.formats || '');
-          const img = item.image ? `<img src="${esc(item.image)}" onerror="this.remove()">` : '';
+          const img = item.image ? `<img src="${esc(httpsImg(item.image))}" onerror="this.remove()">` : '';
           const safeName = (item.text||'').replace(/\\/g,'\\\\').replace(/'/g,"\\'");
-          const safeImg  = (item.image||'').replace(/\\/g,'\\\\').replace(/'/g,"\\'");
+          const safeImg  = httpsImg(item.image||'').replace(/\\/g,'\\\\').replace(/'/g,"\\'");
           return `<div class="result-item" onclick="pickStation(${n},'s${sid}','${safeName}','${safeImg}')">
             ${img}<div><div class="r-name">${name}</div><div class="r-sub">${sub}</div></div>
           </div>`;
@@ -337,6 +337,11 @@
 
     function esc(s) {
       return (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+    }
+
+    // TuneIn CDN serves over HTTPS — upgrade HTTP image URLs to avoid ad-blocker blocks
+    function httpsImg(url) {
+      return (url||'').replace(/^http:\/\/(cdn[^/]*\.tunein\.com)/, 'https://$1');
     }
 
     const params = new URLSearchParams(location.search);

--- a/src/main/resources/static/presets.html
+++ b/src/main/resources/static/presets.html
@@ -250,7 +250,9 @@
           const name = esc(item.text || '');
           const sub = esc(item.subtext || item.formats || '');
           const img = item.image ? `<img src="${esc(item.image)}" onerror="this.remove()">` : '';
-          return `<div class="result-item" onclick="pickStation(${n},'s${sid}',${JSON.stringify(item.text||'')},${JSON.stringify(item.image||'')})">
+          const safeName = (item.text||'').replace(/\\/g,'\\\\').replace(/'/g,"\\'");
+          const safeImg = (item.image||'').replace(/\\/g,'\\\\').replace(/'/g,"\\'");
+          return `<div class="result-item" onclick="pickStation(${n},'s${sid}','${safeName}','${safeImg}')">
             ${img}<div><div class="r-name">${name}</div><div class="r-sub">${sub}</div></div>
           </div>`;
         }).join('');

--- a/src/main/resources/static/presets.html
+++ b/src/main/resources/static/presets.html
@@ -1,0 +1,348 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Überböse — Presets</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; background: #111; color: #eee; padding: 1rem; max-width: 700px; margin: 0 auto; }
+    h1 { font-size: 1.3rem; margin-bottom: 0.2rem; }
+    .subtitle { color: #888; font-size: 0.85rem; margin-bottom: 1.25rem; }
+    .config { display: flex; gap: 0.5rem; margin-bottom: 1.25rem; }
+    .config input { flex: 1; padding: 0.5rem 0.75rem; border-radius: 6px; border: 1px solid #333; background: #1e1e1e; color: #eee; font-size: 0.9rem; }
+    .config button { padding: 0.5rem 1rem; border-radius: 6px; border: none; background: #2563eb; color: #fff; cursor: pointer; font-size: 0.9rem; }
+
+    .preset-card { background: #1a1a1a; border-radius: 10px; border: 1px solid #2a2a2a; margin-bottom: 0.75rem; overflow: hidden; }
+    .preset-header { display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem; }
+    .preset-num { font-size: 1.3rem; font-weight: 700; color: #60a5fa; width: 1.8rem; text-align: center; flex-shrink: 0; }
+    .preset-art { width: 42px; height: 42px; border-radius: 6px; object-fit: cover; background: #2a2a2a; flex-shrink: 0; }
+    .preset-art-empty { width: 42px; height: 42px; border-radius: 6px; background: #2a2a2a; flex-shrink: 0; display: flex; align-items: center; justify-content: center; color: #444; font-size: 1.2rem; }
+    .preset-info { flex: 1; min-width: 0; }
+    .preset-name { font-weight: 600; font-size: 0.95rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .preset-source { font-size: 0.75rem; color: #888; margin-top: 0.1rem; }
+    .preset-btns { display: flex; gap: 0.4rem; flex-shrink: 0; }
+    .btn { padding: 0.35rem 0.65rem; border-radius: 5px; border: none; cursor: pointer; font-size: 0.78rem; font-weight: 500; }
+    .btn-play { background: #166534; color: #86efac; }
+    .btn-play:hover { background: #15803d; }
+    .btn-edit { background: #1e3a8a; color: #93c5fd; }
+    .btn-edit:hover { background: #1d4ed8; }
+    .btn-edit.active { background: #1d4ed8; }
+    .btn-remove { background: #450a0a; color: #fca5a5; }
+    .btn-remove:hover { background: #7f1d1d; }
+    .btn:disabled { opacity: 0.35; cursor: not-allowed; }
+
+    .editor { display: none; border-top: 1px solid #2a2a2a; padding: 0.875rem; background: #141414; }
+    .editor.open { display: block; }
+    .editor-row { display: flex; gap: 0.5rem; margin-bottom: 0.6rem; flex-wrap: wrap; }
+    .editor-row label { font-size: 0.75rem; color: #888; display: block; margin-bottom: 0.2rem; }
+    .editor-row input, .editor-row select { width: 100%; padding: 0.45rem 0.65rem; border-radius: 5px; border: 1px solid #333; background: #1a1a1a; color: #eee; font-size: 0.85rem; }
+    .editor-row input:focus, .editor-row select:focus { outline: none; border-color: #3b82f6; }
+    .f-half { flex: 1; min-width: 130px; }
+    .f-full { flex: 1 0 100%; }
+    .search-row { display: flex; gap: 0.4rem; margin-bottom: 0.6rem; }
+    .search-row input { flex: 1; padding: 0.45rem 0.65rem; border-radius: 5px; border: 1px solid #333; background: #1a1a1a; color: #eee; font-size: 0.85rem; }
+    .search-row input:focus { outline: none; border-color: #3b82f6; }
+    .search-row button { padding: 0.45rem 0.8rem; border-radius: 5px; border: none; background: #2563eb; color: #fff; cursor: pointer; font-size: 0.82rem; white-space: nowrap; }
+    .results { max-height: 200px; overflow-y: auto; border-radius: 6px; border: 1px solid #2a2a2a; margin-bottom: 0.7rem; display: none; }
+    .result-item { display: flex; align-items: center; gap: 0.5rem; padding: 0.45rem 0.6rem; cursor: pointer; border-bottom: 1px solid #222; }
+    .result-item:last-child { border-bottom: none; }
+    .result-item:hover { background: #1e1e1e; }
+    .result-item img { width: 28px; height: 28px; border-radius: 4px; object-fit: cover; flex-shrink: 0; }
+    .result-item .r-name { font-size: 0.85rem; font-weight: 500; }
+    .result-item .r-sub { font-size: 0.72rem; color: #888; }
+    .editor-actions { display: flex; gap: 0.5rem; margin-top: 0.4rem; }
+    .btn-save { flex: 1; padding: 0.5rem; border-radius: 6px; border: none; background: #2563eb; color: #fff; cursor: pointer; font-weight: 600; font-size: 0.88rem; }
+    .btn-save:hover { background: #1d4ed8; }
+    .btn-cancel { padding: 0.5rem 0.8rem; border-radius: 6px; border: 1px solid #333; background: none; color: #888; cursor: pointer; font-size: 0.88rem; }
+    .msg { font-size: 0.78rem; margin-top: 0.5rem; }
+    .msg.ok { color: #4ade80; }
+    .msg.err { color: #f87171; }
+    #status { margin-top: 0.75rem; font-size: 0.82rem; color: #888; }
+    #status.ok { color: #4ade80; }
+    #status.err { color: #f87171; }
+  </style>
+</head>
+<body>
+  <h1>Überböse Presets</h1>
+  <p class="subtitle">Manage speaker preset buttons 1–6</p>
+
+  <div class="config">
+    <input id="speakerIp" placeholder="Speaker IP  (e.g. 192.168.30.10)">
+    <button onclick="loadSpeaker()">Load</button>
+  </div>
+
+  <div id="presets"></div>
+  <p id="status"></p>
+
+  <script>
+    let speakerIp = '';
+    let accountId = '';
+    let deviceId = '';
+    let currentPresets = {};
+
+    function setStatus(msg, type) {
+      const el = document.getElementById('status');
+      el.textContent = msg;
+      el.className = type || '';
+    }
+
+    async function loadSpeaker() {
+      speakerIp = document.getElementById('speakerIp').value.trim();
+      if (!speakerIp) { setStatus('Enter speaker IP', 'err'); return; }
+      setStatus('Loading…');
+      try {
+        const infoResp = await fetch(`/speaker-proxy/speaker-info/${speakerIp}`);
+        if (!infoResp.ok) throw new Error('Cannot reach speaker at ' + speakerIp);
+        const xml = await infoResp.text();
+        const macMatch = xml.match(/deviceID="([^"]+)"/);
+        const uuidMatch = xml.match(/<margeAccountUUID>([^<]+)<\/margeAccountUUID>/);
+        deviceId = macMatch ? macMatch[1] : speakerIp.replace(/\./g,'');
+        accountId = (uuidMatch && uuidMatch[1]) ? uuidMatch[1] : deviceId;
+        await loadPresets();
+      } catch(e) {
+        setStatus('Error: ' + e.message, 'err');
+      }
+    }
+
+    async function loadPresets() {
+      const resp = await fetch(`/streaming/account/${accountId}/device/${deviceId}/presets`, {
+        headers: { Accept: 'application/vnd.bose.streaming-v1.2+xml' }
+      });
+      const xml = await resp.text();
+      currentPresets = {};
+      const doc = new DOMParser().parseFromString(xml, 'application/xml');
+      doc.querySelectorAll('preset').forEach(p => {
+        const n = parseInt(p.getAttribute('buttonNumber'));
+        currentPresets[n] = {
+          name: p.querySelector('name')?.textContent || '',
+          location: p.querySelector('location')?.textContent || '',
+          contentItemType: p.querySelector('contentItemType')?.textContent || '',
+          containerArt: p.querySelector('containerArt')?.textContent || '',
+          sourceid: p.querySelector('source')?.getAttribute('id') || '',
+          sourceproviderid: p.querySelector('sourceproviderid')?.textContent || '',
+        };
+      });
+      renderAll();
+      setStatus('');
+    }
+
+    function renderAll() {
+      const c = document.getElementById('presets');
+      c.innerHTML = '';
+      for (let i = 1; i <= 6; i++) c.appendChild(makeCard(i));
+    }
+
+    function makeCard(n) {
+      const p = currentPresets[n];
+      const isTuneIn = p && p.sourceproviderid === '25';
+      const isRadio = p && (p.sourceproviderid === '11' || p.sourceproviderid === '2');
+      const sourceLabel = p ? (isTuneIn ? 'TuneIn' : isRadio ? 'Internet Radio' : 'Source') : 'Empty';
+
+      const card = document.createElement('div');
+      card.className = 'preset-card';
+      card.id = 'card-' + n;
+
+      const artHtml = (p && p.containerArt)
+        ? `<img class="preset-art" src="${esc(p.containerArt)}" onerror="this.style.display='none';this.nextSibling.style.display='flex'"><div class="preset-art-empty" style="display:none">♪</div>`
+        : `<div class="preset-art-empty">♪</div>`;
+
+      const stationId = isTuneIn ? ((p.location||'').match(/\/v1\/playback\/station\/(s?\d+)/)?.[1]||'') : '';
+      const defaultType = isTuneIn ? 'tunein' : (isRadio ? 'radio' : 'tunein');
+
+      card.innerHTML = `
+        <div class="preset-header">
+          <div class="preset-num">${n}</div>
+          ${artHtml}
+          <div class="preset-info">
+            <div class="preset-name">${p ? esc(p.name) : '<span style="color:#444;font-style:italic">Empty</span>'}</div>
+            <div class="preset-source">${sourceLabel}</div>
+          </div>
+          <div class="preset-btns">
+            <button class="btn btn-play" onclick="playPreset(${n})" ${!p?'disabled':''}>▶</button>
+            <button class="btn btn-edit" id="edit-btn-${n}" onclick="toggleEditor(${n})">✎ Edit</button>
+            <button class="btn btn-remove" onclick="removePreset(${n})" ${!p?'disabled':''}>✕</button>
+          </div>
+        </div>
+        <div class="editor" id="editor-${n}">
+          <div class="editor-row">
+            <div class="f-half">
+              <label>Source type</label>
+              <select id="type-${n}" onchange="onTypeChange(${n})">
+                <option value="tunein" ${defaultType==='tunein'?'selected':''}>TuneIn radio</option>
+                <option value="radio" ${defaultType==='radio'?'selected':''}>Internet radio URL</option>
+              </select>
+            </div>
+            <div class="f-half" id="sid-field-${n}">
+              <label>Station ID</label>
+              <input id="sid-${n}" placeholder="s24903" value="${esc(stationId)}">
+            </div>
+            <div class="f-half" id="url-field-${n}" style="display:none">
+              <label>Stream URL</label>
+              <input id="url-${n}" placeholder="http://…" value="${esc(isTuneIn||!p?'':p.location||'')}">
+            </div>
+          </div>
+          <div class="search-row" id="search-row-${n}">
+            <input id="search-${n}" placeholder="Search TuneIn…" onkeydown="if(event.key==='Enter')doSearch(${n})">
+            <button onclick="doSearch(${n})">Search</button>
+          </div>
+          <div class="results" id="results-${n}"></div>
+          <div class="editor-row">
+            <div class="f-half">
+              <label>Name</label>
+              <input id="name-${n}" placeholder="Station name" value="${esc(p?p.name:'')}">
+            </div>
+            <div class="f-half">
+              <label>Artwork URL (optional)</label>
+              <input id="art-${n}" placeholder="https://…" value="${esc(p?p.containerArt:'')}">
+            </div>
+          </div>
+          <div class="editor-actions">
+            <button class="btn-cancel" onclick="toggleEditor(${n})">Cancel</button>
+            <button class="btn-save" onclick="savePreset(${n})">Save to preset ${n}</button>
+          </div>
+          <div class="msg" id="msg-${n}"></div>
+        </div>`;
+      return card;
+    }
+
+    function toggleEditor(n) {
+      const ed = document.getElementById('editor-' + n);
+      const btn = document.getElementById('edit-btn-' + n);
+      const isOpen = ed.classList.contains('open');
+      // Close all
+      document.querySelectorAll('.editor.open').forEach(e => e.classList.remove('open'));
+      document.querySelectorAll('.btn-edit.active').forEach(b => b.classList.remove('active'));
+      if (!isOpen) {
+        ed.classList.add('open');
+        btn.classList.add('active');
+        onTypeChange(n);
+      }
+    }
+
+    function onTypeChange(n) {
+      const t = document.getElementById('type-' + n)?.value;
+      const sid = document.getElementById('sid-field-' + n);
+      const url = document.getElementById('url-field-' + n);
+      const sr = document.getElementById('search-row-' + n);
+      if (sid) sid.style.display = t === 'tunein' ? '' : 'none';
+      if (url) url.style.display = t === 'radio' ? '' : 'none';
+      if (sr) sr.style.display = t === 'tunein' ? '' : 'none';
+      const res = document.getElementById('results-' + n);
+      if (res) res.style.display = 'none';
+    }
+
+    async function doSearch(n) {
+      const q = document.getElementById('search-' + n).value.trim();
+      if (!q) return;
+      const res = document.getElementById('results-' + n);
+      res.innerHTML = '<div class="result-item"><span style="color:#888;font-size:0.83rem">Searching…</span></div>';
+      res.style.display = 'block';
+      try {
+        const data = await fetch('/speaker-proxy/tunein-search?q=' + encodeURIComponent(q)).then(r => r.json());
+        const items = (data.body || []).filter(i => i.type === 'audio' || i.item === 'station');
+        if (!items.length) {
+          res.innerHTML = '<div class="result-item"><span style="color:#888;font-size:0.83rem">No results</span></div>';
+          return;
+        }
+        res.innerHTML = items.slice(0, 15).map(item => {
+          const sid = (item.guide_id || item.preset_id || '').replace(/^s/,'');
+          const name = esc(item.text || '');
+          const sub = esc(item.subtext || item.formats || '');
+          const img = item.image ? `<img src="${esc(item.image)}" onerror="this.remove()">` : '';
+          return `<div class="result-item" onclick="pickStation(${n},'s${sid}',${JSON.stringify(item.text||'')},${JSON.stringify(item.image||'')})">
+            ${img}<div><div class="r-name">${name}</div><div class="r-sub">${sub}</div></div>
+          </div>`;
+        }).join('');
+      } catch(e) {
+        res.innerHTML = `<div class="result-item"><span style="color:#f87171;font-size:0.83rem">Error: ${e.message}</span></div>`;
+      }
+    }
+
+    function pickStation(n, stationId, name, imageUrl) {
+      document.getElementById('sid-' + n).value = stationId;
+      if (name && !document.getElementById('name-' + n).value)
+        document.getElementById('name-' + n).value = name;
+      if (imageUrl && !document.getElementById('art-' + n).value)
+        document.getElementById('art-' + n).value = imageUrl;
+      document.getElementById('results-' + n).style.display = 'none';
+      document.getElementById('search-' + n).value = '';
+    }
+
+    async function playPreset(n) {
+      const xml1 = `<key state="press" sender="Gabbo">PRESET_${n}</key>`;
+      const xml2 = `<key state="release" sender="Gabbo">PRESET_${n}</key>`;
+      await fetch(`/speaker-proxy/${speakerIp}/key`, {method:'POST',body:xml1,headers:{'Content-Type':'application/xml'}});
+      await fetch(`/speaker-proxy/${speakerIp}/key`, {method:'POST',body:xml2,headers:{'Content-Type':'application/xml'}});
+      setStatus('Playing preset ' + n, 'ok');
+    }
+
+    async function removePreset(n) {
+      if (!confirm(`Remove preset ${n}?`)) return;
+      await fetch(`/speaker-proxy/${speakerIp}/removePreset`, {
+        method:'POST', body:`<preset buttonNumber="${n}"/>`,
+        headers:{'Content-Type':'application/xml'}
+      }).catch(()=>{});
+      await fetch(`/streaming/account/${accountId}/device/${deviceId}/preset/${n}`, {method:'DELETE'});
+      await loadPresets();
+      setStatus('Preset ' + n + ' removed', 'ok');
+    }
+
+    async function savePreset(n) {
+      const type = document.getElementById('type-' + n).value;
+      const name = document.getElementById('name-' + n).value.trim();
+      const art = document.getElementById('art-' + n).value.trim();
+      const msgEl = document.getElementById('msg-' + n);
+
+      let location, contentItemType, speakerXml;
+
+      if (type === 'tunein') {
+        const raw = document.getElementById('sid-' + n).value.trim();
+        const sid = raw.replace(/^s/,'');
+        if (!sid) { msgEl.textContent = 'Enter a station ID or search above'; msgEl.className = 'msg err'; return; }
+        location = `/v1/playback/station/s${sid}`;
+        contentItemType = 'stationurl';
+        speakerXml = `<ContentItem source="TUNEIN" type="stationurl" location="${location}" sourceAccount="" isPresetable="true"><itemName>${esc(name)}</itemName></ContentItem>`;
+      } else {
+        const url = document.getElementById('url-' + n).value.trim();
+        if (!url) { msgEl.textContent = 'Enter a stream URL'; msgEl.className = 'msg err'; return; }
+        const encoded = btoa(JSON.stringify({ name, imageUrl: art, streamUrl: url }));
+        location = `/core02/svc-bmx-adapter-orion/prod/orion/station?data=${encoded}`;
+        contentItemType = 'stationurl';
+        speakerXml = `<ContentItem source="LOCAL_INTERNET_RADIO" type="stationurl" location="${location}" sourceAccount="" isPresetable="true"><itemName>${esc(name)}</itemName></ContentItem>`;
+      }
+
+      msgEl.textContent = 'Saving…'; msgEl.className = 'msg';
+
+      // Push to speaker
+      await fetch(`/speaker-proxy/${speakerIp}/storePreset`, {
+        method:'POST',
+        body: `<preset buttonNumber="${n}">${speakerXml}</preset>`,
+        headers:{'Content-Type':'application/xml'}
+      }).catch(()=>{});
+
+      // Save to Überböse API DB
+      const apiBody = `<?xml version="1.0" encoding="UTF-8"?><preset buttonNumber="${n}"><sourceid>1</sourceid><name>${esc(name)}</name><username>${esc(name)}</username><location>${esc(location)}</location><contentItemType>${contentItemType}</contentItemType><containerArt>${esc(art)}</containerArt></preset>`;
+      await fetch(`/streaming/account/${accountId}/device/${deviceId}/preset/${n}`, {
+        method:'PUT',
+        headers:{'Content-Type':'application/vnd.bose.streaming-v1.2+xml'},
+        body: apiBody
+      });
+
+      msgEl.textContent = '✓ Saved'; msgEl.className = 'msg ok';
+      setTimeout(() => { msgEl.textContent = ''; }, 2000);
+      await loadPresets();
+    }
+
+    function esc(s) {
+      return (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+    }
+
+    const params = new URLSearchParams(location.search);
+    if (params.get('ip')) {
+      document.getElementById('speakerIp').value = params.get('ip');
+      window.addEventListener('load', loadSpeaker);
+    }
+  </script>
+</body>
+</html>

--- a/src/main/resources/static/presets.html
+++ b/src/main/resources/static/presets.html
@@ -339,9 +339,11 @@
       return (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
     }
 
-    // TuneIn CDN serves over HTTPS — upgrade HTTP image URLs to avoid ad-blocker blocks
+    // Proxy TuneIn CDN images through the API to avoid ad-blocker blocks
     function httpsImg(url) {
-      return (url||'').replace(/^http:\/\/(cdn[^/]*\.tunein\.com)/, 'https://$1');
+      if (!url) return '';
+      if (url.includes('tunein.com')) return '/speaker-proxy/image?url=' + encodeURIComponent(url);
+      return url;
     }
 
     const params = new URLSearchParams(location.search);

--- a/src/main/resources/static/presets.html
+++ b/src/main/resources/static/presets.html
@@ -251,7 +251,7 @@
           const sub = esc(item.subtext || item.formats || '');
           const img = item.image ? `<img src="${esc(item.image)}" onerror="this.remove()">` : '';
           const safeName = (item.text||'').replace(/\\/g,'\\\\').replace(/'/g,"\\'");
-          const safeImg = (item.image||'').replace(/\\/g,'\\\\').replace(/'/g,"\\'");
+          const safeImg  = (item.image||'').replace(/\\/g,'\\\\').replace(/'/g,"\\'");
           return `<div class="result-item" onclick="pickStation(${n},'s${sid}','${safeName}','${safeImg}')">
             ${img}<div><div class="r-name">${name}</div><div class="r-sub">${sub}</div></div>
           </div>`;

--- a/src/main/resources/static/presets.html
+++ b/src/main/resources/static/presets.html
@@ -271,20 +271,23 @@
       document.getElementById('search-' + n).value = '';
     }
 
+    // Send a command directly to the speaker from the browser (bypasses CORS using no-cors mode).
+    // Used for fire-and-forget operations where we don't need the response.
+    function speakerPost(path, body) {
+      return fetch(`http://${speakerIp}:8090${path}`, {
+        method: 'POST', mode: 'no-cors', body,
+      }).catch(() => {});
+    }
+
     async function playPreset(n) {
-      const xml1 = `<key state="press" sender="Gabbo">PRESET_${n}</key>`;
-      const xml2 = `<key state="release" sender="Gabbo">PRESET_${n}</key>`;
-      await fetch(`/speaker-proxy/${speakerIp}/key`, {method:'POST',body:xml1,headers:{'Content-Type':'application/xml'}});
-      await fetch(`/speaker-proxy/${speakerIp}/key`, {method:'POST',body:xml2,headers:{'Content-Type':'application/xml'}});
+      await speakerPost('/key', `<key state="press" sender="Gabbo">PRESET_${n}</key>`);
+      await speakerPost('/key', `<key state="release" sender="Gabbo">PRESET_${n}</key>`);
       setStatus('Playing preset ' + n, 'ok');
     }
 
     async function removePreset(n) {
       if (!confirm(`Remove preset ${n}?`)) return;
-      await fetch(`/speaker-proxy/${speakerIp}/removePreset`, {
-        method:'POST', body:`<preset buttonNumber="${n}"/>`,
-        headers:{'Content-Type':'application/xml'}
-      }).catch(()=>{});
+      await speakerPost('/removePreset', `<preset buttonNumber="${n}"/>`);
       await fetch(`/streaming/account/${accountId}/device/${deviceId}/preset/${n}`, {method:'DELETE'});
       await loadPresets();
       setStatus('Preset ' + n + ' removed', 'ok');
@@ -316,12 +319,8 @@
 
       msgEl.textContent = 'Saving…'; msgEl.className = 'msg';
 
-      // Push to speaker
-      await fetch(`/speaker-proxy/${speakerIp}/storePreset`, {
-        method:'POST',
-        body: `<preset buttonNumber="${n}">${speakerXml}</preset>`,
-        headers:{'Content-Type':'application/xml'}
-      }).catch(()=>{});
+      // Push to speaker directly (no-cors, fire-and-forget)
+      await speakerPost('/storePreset', `<preset buttonNumber="${n}">${speakerXml}</preset>`);
 
       // Save to Überböse API DB
       const apiBody = `<?xml version="1.0" encoding="UTF-8"?><preset buttonNumber="${n}"><sourceid>1</sourceid><name>${esc(name)}</name><username>${esc(name)}</username><location>${esc(location)}</location><contentItemType>${contentItemType}</contentItemType><containerArt>${esc(art)}</containerArt></preset>`;

--- a/ueberboese-api.yaml
+++ b/ueberboese-api.yaml
@@ -3485,9 +3485,6 @@ components:
     BmxTokenRequest:
       type: object
       description: Token refresh request
-      required:
-        - grant_type
-        - refresh_token
       properties:
         grant_type:
           type: string


### PR DESCRIPTION
## Summary

- Adds a browser-based preset management UI served at `/presets.html`
- Supports searching TuneIn stations, viewing artwork, playing, saving and removing presets 1–6
- Includes auto-provisioning of never-paired speakers and anonymous TuneIn support (dependency for the UI)
- Fixes: User-Agent on TuneIn requests, double-encoded JSON, XSS-safe onclick escaping, HTTP→HTTPS image URLs, image proxy to bypass ad-blocker blocks

## Test plan

- [ ] Open `http://<your-api>:8080/presets.html` in a browser
- [ ] Enter speaker IP and click Load — presets should appear with artwork
- [ ] Search TuneIn, pick a station, save to a preset slot
- [ ] Play a preset from the UI
- [ ] Remove a preset
- [ ] Test with a never-paired (factory-fresh) speaker — should auto-provision