### PR TITLE
feat: add client IP to the log info

### DIFF
--- a/src/main/java/com/github/juliusd/ueberboeseapi/filter/RequestLoggingFilter.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/filter/RequestLoggingFilter.java
@@ -31,7 +31,16 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
     String uri = request.getRequestURI();
     String queryString = request.getQueryString();
     String fullUri = queryString != null ? uri + "?" + queryString : uri;
-    log.info("Request: {} {}", request.getMethod(), fullUri);
+
+    String clientIp = request.getHeader("X-Forwarded-For");
+    if (clientIp == null || clientIp.isEmpty() || "unknown".equalsIgnoreCase(clientIp)) {
+      clientIp = request.getRemoteAddr();
+    }
+    if (clientIp != null && clientIp.contains(",")) {
+      clientIp = clientIp.split(",")[0].trim();
+    }
+
+    log.info("Request from [{}]: {} {}", clientIp, request.getMethod(), fullUri);
 
     boolean isEventReport = uri.matches(".*/v1/scmudc/.*");
     boolean isBmxReport = uri.matches(".*/bmx/.+/v1/report.*");
@@ -41,19 +50,22 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
       ContentCachingRequestWrapper wrappedRequest =
           new ContentCachingRequestWrapper(request, 1024 * 1024);
 
-      // Continue with the filter chain
       filterChain.doFilter(wrappedRequest, response);
 
-      // Log the raw request body after the request has been processed
       byte[] content = wrappedRequest.getContentAsByteArray();
       if (content.length > 0) {
         String rawBody = new String(content, StandardCharsets.UTF_8);
         if (isEventReport) {
-          EVENT_LOG.info("event: {}", rawBody.trim());
+          EVENT_LOG.info("event from [{}]: {}", clientIp, rawBody.trim());
         } else if (isBmxReport) {
-          EVENT_LOG.info("bxm-report: {}", rawBody.trim());
+          EVENT_LOG.info("bxm-report from [{}]: {}", clientIp, rawBody.trim());
         } else if (response.getStatus() >= 400) {
-          log.warn("POST {} failed (HTTP {}): {}", uri, response.getStatus(), rawBody.trim());
+          log.warn(
+              "POST {} from [{}] failed (HTTP {}): {}",
+              uri,
+              clientIp,
+              response.getStatus(),
+              rawBody.trim());
         }
       }
     } else {


### PR DESCRIPTION
## Change Summary
### Short Description
This PR enhances the logging capabilities of the RequestLoggingFilter by capturing and displaying the real-time client IP address for all incoming API requests. It dynamically handles reverse proxies by extracting the source IP from the X-Forwarded-For header with a graceful fallback to the remote address.

### Key Changes
Proxy-Aware IP Extraction: Added logic to inspect the X-Forwarded-For header. If multiple proxy IPs are present in a chain, it safely extracts the initial client IP (the Bose speaker itself).

Enhanced Logging Output: Updated the default request log message to explicitly format the client IP, turning standard logs into a more informative trace: Request from [192.168.1.50]: GET /v1/presets.

Contextual Event Logs: Integrated the client IP address into context-specific warnings and specialized event log files (e.g., EVENT_LOG and bxm-report).
