### PR TITLE
feat: implement dynamic Spotify account matching and token rotation

### DIFF
--- a/src/main/java/com/github/juliusd/ueberboeseapi/spotify/SpotifyAccountService.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/spotify/SpotifyAccountService.java
@@ -44,6 +44,50 @@ public class SpotifyAccountService {
   }
 
   /**
+   * Updates the refresh token and updatedAt timestamp for an existing Spotify account, but ONLY if
+   * the refresh token has actually changed.
+   *
+   * @param spotifyUserId The Spotify user ID
+   * @param newRefreshToken The new refresh token to store
+   */
+  public void updateRefreshToken(String spotifyUserId, String newRefreshToken) {
+    log.debug("Checking refresh token update requirements for userId: {}", spotifyUserId);
+
+    repository
+        .findById(spotifyUserId)
+        .ifPresentOrElse(
+            existingAccount -> {
+              // Check if the token has actually changed
+              if (existingAccount.refreshToken().equals(newRefreshToken)) {
+                log.debug(
+                    "Refresh token for userId: {} has not changed. Skipping database write to optimize performance.",
+                    spotifyUserId);
+                return;
+              }
+
+              // If changed (or rotated by Spotify), persist the new token
+              OffsetDateTime now = OffsetDateTime.now();
+              SpotifyAccount updatedAccount =
+                  new SpotifyAccount(
+                      existingAccount.spotifyUserId(),
+                      existingAccount.displayName(),
+                      newRefreshToken,
+                      existingAccount.createdAt(),
+                      now,
+                      existingAccount.version());
+
+              repository.save(updatedAccount);
+              log.info(
+                  "Refresh token rotated! Successfully updated Spotify refresh token in database for userId: {}",
+                  spotifyUserId);
+            },
+            () ->
+                log.warn(
+                    "Key rotation skipped: No existing Spotify account found for userId: {}",
+                    spotifyUserId));
+  }
+
+  /**
    * Retrieves a Spotify account by Spotify user ID.
    *
    * @param spotifyUserId The Spotify user ID
@@ -55,7 +99,7 @@ public class SpotifyAccountService {
     Optional<SpotifyAccount> account = repository.findById(spotifyUserId);
 
     if (account.isPresent()) {
-      log.info("Successfully loaded Spotify account for accountId: {}", spotifyUserId);
+      log.debug("Successfully loaded Spotify account for accountId: {}", spotifyUserId);
     } else {
       log.debug("Spotify account not found for userId: {}", spotifyUserId);
     }
@@ -83,7 +127,7 @@ public class SpotifyAccountService {
 
     List<SpotifyAccount> accounts = repository.findAllByOrderByCreatedAtDesc();
 
-    log.info("Found {} Spotify account(s)", accounts.size());
+    log.debug("Found {} Spotify account(s)", accounts.size());
     return accounts;
   }
 }

--- a/src/main/java/com/github/juliusd/ueberboeseapi/spotify/SpotifyTokenService.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/spotify/SpotifyTokenService.java
@@ -34,7 +34,6 @@ public class SpotifyTokenService {
       OAuthTokenRequestApiDto oauthTokenRequestApiDto) {
     checkProperties();
 
-    // Get the oldest connected Spotify account
     var accounts = spotifyAccountService.listAllAccounts();
     if (accounts.isEmpty()) {
       log.error("No Spotify accounts connected");
@@ -42,23 +41,39 @@ public class SpotifyTokenService {
           "No Spotify accounts connected. Please connect a Spotify account via the management API.");
     }
 
-    // Use the oldest account (last in the list sorted by createdAt descending)
-    var oldestAccount = accounts.getLast();
-    log.info(
-        "Using Spotify account: {} ({})",
-        oldestAccount.displayName(),
-        oldestAccount.spotifyUserId());
+    // Determine which account to use based on the incoming request refresh token
+    SpotifyAccount targetAccount = null;
+    String incomingRefreshToken = oauthTokenRequestApiDto.getRefreshToken();
 
-    if (oldestAccount.refreshToken().equals(oauthTokenRequestApiDto.getRefreshToken())) {
-      log.info("Refresh token match!");
+    if (incomingRefreshToken != null && !incomingRefreshToken.isBlank()) {
+      // Try to find the exact matching account in our database
+      for (SpotifyAccount account : accounts) {
+        if (incomingRefreshToken.equals(account.refreshToken())) {
+          targetAccount = account;
+          log.debug(
+              "Matched incoming refresh token to Spotify account: {} ({})",
+              account.displayName(),
+              account.spotifyUserId());
+          break;
+        }
+      }
+    }
+
+    // Fallback if no explicit match was found
+    if (targetAccount == null) {
+      targetAccount = accounts.getLast();
+      log.info(
+          "No exact refresh token match found. Falling back to oldest account: {} ({})",
+          targetAccount.displayName(),
+          targetAccount.spotifyUserId());
     }
 
     try {
-      // Prepare form data for token refresh
+      // Prepare form data for token refresh using the resolved account
       org.springframework.util.LinkedMultiValueMap<String, String> formData =
           new org.springframework.util.LinkedMultiValueMap<>();
       formData.add("grant_type", "refresh_token");
-      formData.add("refresh_token", oldestAccount.refreshToken());
+      formData.add("refresh_token", targetAccount.refreshToken());
       formData.add("client_id", spotifyAuthProperties.clientId());
       formData.add("client_secret", spotifyAuthProperties.clientSecret());
 
@@ -66,10 +81,21 @@ public class SpotifyTokenService {
       var authorizationCodeCredentials = spotifyOAuthClient.refreshAccessToken(formData);
 
       String actualScope = authorizationCodeCredentials.scope();
-      log.info("Spotify auth refresh request successful with scope {}", actualScope);
+      log.debug("Spotify auth refresh request successful with scope {}", actualScope);
 
       // Validate that all required scopes are present
       validateScopes(actualScope);
+
+      // Check if Spotify returned a brand new or rotated refresh token
+      String latestRefreshToken = authorizationCodeCredentials.refreshToken();
+      if (latestRefreshToken == null || latestRefreshToken.isBlank()) {
+        // If Spotify does not issue a new token, retain the current active one
+        log.debug("No refresh token issued by Spotify, retain the current active one");
+        latestRefreshToken = targetAccount.refreshToken();
+      }
+
+      // Persist the (potentially rotated) token and refresh the 'updatedAt' timestamp
+      spotifyAccountService.updateRefreshToken(targetAccount.spotifyUserId(), latestRefreshToken);
 
       return authorizationCodeCredentials;
     } catch (RuntimeException e) {


### PR DESCRIPTION
## Description
This PR resolves limitations in multi-room/multi-user setups by introducing dynamic Spotify account matching based on the incoming speaker request. 

Additionally, it adds robust persistence support to handle Spotify's *Refresh Token Rotation* mechanism, ensuring that whenever Spotify issues a new refresh token during a stream init, it is immediately updated in the database to prevent abrupt connection drops.

## Changes
### 🔐 Spotify Authentication Pipeline (`SpotifyTokenService`)
* **Dynamic Account Resolution:** Refactored `loadSpotifyAuth` to extract and inspect the incoming `refresh_token` from the speaker's request payload. The service now dynamically searches the database for the exact matching user record.
* **Smart Fallback:** Maintained a resilient fallback strategy that defaults to the oldest registered account only if the incoming token is missing or doesn't match any record.
* **Token Rotation Hook:** Intercepted the token refresh response from Spotify to capture newly rotated refresh tokens (`latestRefreshToken`).

### 💾 Storage & Performance Optimization (`SpotifyAccountService`)
* **Token Persistence:** Introduced the `updateRefreshToken` routine to safely commit rotated credentials back to the database, ensuring our records remain the single source of truth for downstream speakers.
* **Write Optimization:** Implemented a short-circuit check (`equals()`) that skips the database write entirely if Spotify returns the exact same refresh token, minimizing write overhead and preventing unnecessary `@Version` optimistic locking increments.
