### PR TITLE
fix: increase JVM MaxDirectMemorySize to prevent Netty OOM during TLS, fixes #61

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -24,6 +24,10 @@ services:
       - "8081:8081"      # Management/Actuator endpoints
     environment:
       - TZ=Europe/Berlin
+      # Memory increase options
+      # -XX:MaxDirectMemorySize=256m: Raises the Netty direct memory allocation pool from ~10MB to 256MB, giving the TLS handshakes plenty of headroom.
+      # -Xmx512m: Ensures the standard Java Heap size is safely bounded alongside the new direct memory allocation.
+      - JAVA_TOOL_OPTIONS=-XX:MaxDirectMemorySize=256m -Xmx512m
       # Spotify OAuth is disabled by default, you need it only for Spotify presets
       - UEBERBOESE_OAUTH_ENABLED=true
       # Spotify API authentication (required for OAuth token refresh)


### PR DESCRIPTION
### 🐛 Bug Analysis & Solution

The application crashes with an `OutOfDirectMemoryError` when making outbound API calls (specifically during the TLS handshake with the Spotify API). 

```text
2026-05-18 15:39:07.816 [http-nio-8080-exec-2] ERROR o.a.c.c.C.[.[.[.[dispatcherServlet] - Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: com.github.juliusd.ueberboeseapi.spotify.SpotifyException: org.springframework.web.client.ResourceAccessException: I/O error on POST request for "https://accounts.spotify.com/api/token": failure when writing TLS control frames] with root cause
io.netty.util.internal.OutOfDirectMemoryError: failed to allocate 131072 byte(s) of direct memory (used: 10379264, max: 10485760)
at io.netty.util.internal.PlatformDependent.incrementMemoryCounter(PlatformDependent.java:1102)
```

**Root Cause:**
The underlying Netty network engine utilizes off-heap Direct Memory for buffering network I/O. The logs indicate that the maximum allowed Direct Memory is currently capped at roughly 10MB (`max: 10485760`), which is insufficient for handling TLS control frames and concurrent HTTP requests.

### Solution

You can resolve this by explicitly increasing the maximum direct memory limit using the JVM flags. Add the following line to the `environment` section of your Docker configuration:

```yaml
    environment:
      - JAVA_TOOL_OPTIONS=-XX:MaxDirectMemorySize=256m -Xmx512m

```

**What these configurations do:**

* `-XX:MaxDirectMemorySize=256m`: Raises the Netty direct memory allocation pool from ~10MB to 256MB, giving the TLS handshakes plenty of headroom.
* `-Xmx512m`: Ensures the standard Java Heap size is safely bounded alongside the new direct memory allocation.
