### PR TITLE
fix: issue anonymous TuneIn token when no refresh token provided

### DIFF
--- a/src/main/java/com/github/juliusd/ueberboeseapi/BmxController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/BmxController.java
@@ -107,9 +107,11 @@ public class BmxController implements BmxApi {
     log.info("Refreshing TuneIn token");
 
     try {
-      String refreshToken = bmxTokenRequestApiDto.getRefreshToken();
+      String refreshToken =
+          bmxTokenRequestApiDto != null ? bmxTokenRequestApiDto.getRefreshToken() : null;
       if (refreshToken == null || refreshToken.isEmpty()) {
-        return ResponseEntity.badRequest().build();
+        refreshToken = java.util.UUID.randomUUID().toString();
+        log.info("No refresh token provided, issuing new anonymous TuneIn token");
       }
 
       BmxTokenResponseApiDto response = bmxService.refreshTuneInToken(refreshToken);

--- a/ueberboese-api.yaml
+++ b/ueberboese-api.yaml
@@ -3485,9 +3485,6 @@ components:
     BmxTokenRequest:
       type: object
       description: Token refresh request
-      required:
-        - grant_type
-        - refresh_token
       properties:
         grant_type:
           type: string


### PR DESCRIPTION
## Summary

- Handles the first-use TuneIn case where `BmxTokenRequest` is absent or has no `refresh_token` — instead of returning `400 Bad Request`, issues a fresh UUID as an anonymous token so the speaker can complete the TuneIn auth flow
- Removes the `required` constraint on `BmxTokenRequest` fields in the OpenAPI spec to reflect that both fields are optional for this anonymous token flow

## Background

On a factory-reset or never-paired device, TuneIn has no prior session so it sends a token request with no `refresh_token`. The previous code returned `400`, causing TuneIn to fail on first use. This fix makes the anonymous token flow work out of the box.

## Test plan

- [ ] POST to `/core02/svc-bmx-adapter-orion/prod/refreshToken` with an empty body — should return `200` with a UUID `access_token`
- [ ] POST with a valid `refresh_token` — existing flow unchanged, token proxied to upstream BMX
- [ ] Verify OpenAPI spec generates `BmxTokenRequest` with optional fields