### PR TITLE
feat(mgmt): add endpoint to list unique marge account IDs

### DIFF
--- a/mgmt-api.yaml
+++ b/mgmt-api.yaml
@@ -307,6 +307,45 @@ paths:
                     error: "Internal server error"
                     message: "Failed to retrieve Spotify accounts"
 
+  /mgmt/accounts:
+    get:
+      summary: List all unique account IDs
+      description: |
+        Retrieves a list of all distinct account IDs (marge_account_id) currently associated with active devices.
+      operationId: listAccountIds
+      tags:
+        - Account Management
+      responses:
+        '200':
+          description: Successfully retrieved list of unique account IDs
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - accountIds
+                properties:
+                  accountIds:
+                    type: array
+                    description: List of distinct marge account IDs
+                    items:
+                      type: string
+                      example: "6921042"
+              examples:
+                success:
+                  summary: Response with distinct accounts
+                  value:
+                    accountIds:
+                      - "0"
+                      - "6921042"
+                      - "7543119"
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /mgmt/accounts/{accountId}/speakers:
     get:
       summary: List speakers for an account

--- a/src/main/java/com/github/juliusd/ueberboeseapi/device/DeviceRepository.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/device/DeviceRepository.java
@@ -13,4 +13,7 @@ public interface DeviceRepository extends CrudRepository<Device, String> {
 
   @Query("SELECT * FROM DEVICE WHERE MARGE_ACCOUNT_ID = :margeAccountId")
   List<Device> findAllByMargeAccountId(String margeAccountId);
+
+  @Query("SELECT DISTINCT MARGE_ACCOUNT_ID FROM DEVICE WHERE MARGE_ACCOUNT_ID IS NOT NULL")
+  List<String> findDistinctMargeAccountIds();
 }

--- a/src/main/java/com/github/juliusd/ueberboeseapi/mgmt/MgmtController.java
+++ b/src/main/java/com/github/juliusd/ueberboeseapi/mgmt/MgmtController.java
@@ -3,11 +3,13 @@ package com.github.juliusd.ueberboeseapi.mgmt;
 import com.github.juliusd.ueberboeseapi.bmx.report.RadioReportEvent;
 import com.github.juliusd.ueberboeseapi.bmx.report.RadioReportStorageService;
 import com.github.juliusd.ueberboeseapi.bmx.report.RadioSessionReport;
+import com.github.juliusd.ueberboeseapi.device.DeviceRepository;
 import com.github.juliusd.ueberboeseapi.generated.mgmt.AccountManagementApi;
 import com.github.juliusd.ueberboeseapi.generated.mgmt.EventManagementApi;
 import com.github.juliusd.ueberboeseapi.generated.mgmt.dtos.DeviceEventApiDto;
 import com.github.juliusd.ueberboeseapi.generated.mgmt.dtos.ErrorApiDto;
 import com.github.juliusd.ueberboeseapi.generated.mgmt.dtos.GetDeviceEvents200ResponseApiDto;
+import com.github.juliusd.ueberboeseapi.generated.mgmt.dtos.ListAccountIds200ResponseApiDto;
 import com.github.juliusd.ueberboeseapi.generated.mgmt.dtos.ListSpeakers200ResponseApiDto;
 import com.github.juliusd.ueberboeseapi.generated.mgmt.dtos.RadioReportEventApiDto;
 import com.github.juliusd.ueberboeseapi.generated.mgmt.dtos.RadioReportSessionApiDto;
@@ -31,6 +33,20 @@ public class MgmtController implements AccountManagementApi, EventManagementApi 
   private final DeviceTrackingService deviceTrackingService;
   private final EventStorageService eventStorageService;
   private final RadioReportStorageService radioReportStorageService;
+  private final DeviceRepository deviceRepository;
+
+  @Override
+  public ResponseEntity<ListAccountIds200ResponseApiDto> listAccountIds() {
+    log.info("Retrieving all unique marge account IDs from active devices");
+
+    List<String> distinctAccountIds = deviceRepository.findDistinctMargeAccountIds();
+
+    ListAccountIds200ResponseApiDto response = new ListAccountIds200ResponseApiDto();
+    response.setAccountIds(distinctAccountIds);
+
+    log.info("Successfully found {} unique account ID(s)", distinctAccountIds.size());
+    return ResponseEntity.ok().header("Content-Type", "application/json").body(response);
+  }
 
   @Override
   public ResponseEntity<ListSpeakers200ResponseApiDto> listSpeakers(String accountId) {

--- a/src/test/java/com/github/juliusd/ueberboeseapi/mgmt/MgmtControllerTest.java
+++ b/src/test/java/com/github/juliusd/ueberboeseapi/mgmt/MgmtControllerTest.java
@@ -107,4 +107,91 @@ class MgmtControllerTest extends TestBase {
         .then()
         .statusCode(401);
   }
+
+  @Test
+  void listAccountIds_shouldReturnDistinctListOfAccountIds() {
+    // Given
+    OffsetDateTime now = OffsetDateTime.now();
+
+    deviceRepository.save(
+        Device.builder()
+            .deviceId("d1")
+            .margeAccountId("6921042")
+            .ipAddress("10.0.0.1")
+            .firstSeen(now)
+            .lastSeen(now)
+            .build());
+    deviceRepository.save(
+        Device.builder()
+            .deviceId("d2")
+            .margeAccountId("6921042")
+            .ipAddress("10.0.0.2")
+            .firstSeen(now)
+            .lastSeen(now)
+            .build()); // Dubbel ID
+    deviceRepository.save(
+        Device.builder()
+            .deviceId("d3")
+            .margeAccountId("0")
+            .ipAddress("10.0.0.3")
+            .firstSeen(now)
+            .lastSeen(now)
+            .build());
+    deviceRepository.save(
+        Device.builder()
+            .deviceId("d4")
+            .margeAccountId("7543119")
+            .ipAddress("10.0.0.4")
+            .firstSeen(now)
+            .lastSeen(now)
+            .build());
+    deviceRepository.save(
+        Device.builder()
+            .deviceId("d5")
+            .margeAccountId(null)
+            .ipAddress("10.0.0.5")
+            .firstSeen(now)
+            .lastSeen(now)
+            .build()); // Null mag niet mee
+
+    // When
+    Response response =
+        given()
+            .auth()
+            .basic("admin", "test-password-123")
+            .accept(ContentType.JSON)
+            .when()
+            .get("/mgmt/accounts");
+
+    // Then
+    response
+        .then()
+        .statusCode(200)
+        .contentType("application/json")
+        .body("accountIds", hasSize(3)) // "6921042", "0", en "7543119"
+        .body("accountIds", containsInAnyOrder("6921042", "0", "7543119"));
+  }
+
+  @Test
+  void listAccountIds_shouldReturnEmptyListWhenNoAccountsExist() {
+    // Given - Geen devices in database
+
+    // When / Then
+    given()
+        .auth()
+        .basic("admin", "test-password-123")
+        .accept(ContentType.JSON)
+        .when()
+        .get("/mgmt/accounts")
+        .then()
+        .statusCode(200)
+        .contentType("application/json")
+        .body("accountIds", hasSize(0));
+  }
+
+  @Test
+  void listAccountIds_shouldRequireAuthentication() {
+    // When / Then
+    given().accept(ContentType.JSON).when().get("/mgmt/accounts").then().statusCode(401);
+  }
 }


### PR DESCRIPTION
## Description
Introduces a new management endpoint (`GET /mgmt/accounts`) to retrieve a distinct list of all active account IDs across tracked devices.

### Key Changes

#### 1. Backend & API Implementation
* **OpenAPI Spec:** Added the `/mgmt/accounts` path to `mgmt-api.yaml` returning an array of string-based account IDs.
* **Database Layer:** Implemented `findDistinctMargeAccountIds()` in `DeviceRepository` to fetch unique, non-null `marge_account_id` entries.
* **Controller:** Added the `listAccountIds()` implementation in `MgmtController` to map the repository results cleanly to the generated API DTO.

#### 2. Testing
* **Integration Tests:** Added test cases to `MgmtControllerTest.java` to verify:
  * Proper collection of distinct account IDs (ensuring duplicate filter and null checks work).
  * Request authentication handling (Basic Auth).
